### PR TITLE
fix: Fix case creation showing 'undefined' instead of case name

### DIFF
--- a/frontend/src/components/CaseList.jsx
+++ b/frontend/src/components/CaseList.jsx
@@ -155,8 +155,7 @@ export default function CaseList({ auth, onSelectCase }) {
         // Ako korisnik nije administrator, dodaj samo ako je taj korisnik dodijeljen slučaju
         if (auth.user.uloga !== 'Administrator') {
           // Provjeri je li novi slučaj dodijeljen ovom korisniku
-          const jeDodijeljenMeni = noviSlucaj.voditelj_slucaja_id === auth.user.userId || 
-                                   noviSlucaj.voditelj_slucaja === auth.user.ime;
+          const jeDodijeljenMeni = noviSlucaj.voditelj_slucaja === auth.user.ime;
           
           if (jeDodijeljenMeni) {
             return [noviSlucaj, ...trenutniSlucajevi];

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/SlucajController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/SlucajController.java
@@ -139,7 +139,7 @@ public class SlucajController {
                 request.setStanicaId(stanicaId);
             }
 
-            Slucaj slucaj = slucajService.kreirajSlucaj(request, userId);
+            SlucajListDTO slucaj = slucajService.kreirajSlucaj(request, userId);
             return ResponseEntity.status(HttpStatus.CREATED).body(slucaj);
         } catch (RuntimeException e) {
             e.printStackTrace();

--- a/suds/src/main/java/ba/unsa/etf/suds/service/SlucajService.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/service/SlucajService.java
@@ -46,7 +46,7 @@ public class SlucajService {
         return slucajRepository.findDetaljiByBroj(brojSlucaja);
     }
 
-    public Slucaj kreirajSlucaj(KreirajSlucajRequest request, Long voditeljUserId) {
+    public SlucajListDTO kreirajSlucaj(KreirajSlucajRequest request, Long voditeljUserId) {
         Connection conn = null;
         try {
             conn = dbManager.getConnection();
@@ -81,8 +81,8 @@ public class SlucajService {
 
             conn.commit();
 
-            slucaj.setSlucajId(slucajId);
-            return slucaj;
+            return slucajRepository.findByIdWithVoditelj(slucajId)
+                    .orElseThrow(() -> new RuntimeException("Failed to fetch created case with ID: " + slucajId));
 
         } catch (SQLException e) {
             if (conn != null) {

--- a/suds/src/test/java/ba/unsa/etf/suds/controller/SlucajControllerRbacTest.java
+++ b/suds/src/test/java/ba/unsa/etf/suds/controller/SlucajControllerRbacTest.java
@@ -1,7 +1,7 @@
 package ba.unsa.etf.suds.controller;
 
 import ba.unsa.etf.suds.dto.KreirajSlucajRequest;
-import ba.unsa.etf.suds.model.Slucaj;
+import ba.unsa.etf.suds.dto.SlucajListDTO;
 import ba.unsa.etf.suds.security.JwtUtil;
 import ba.unsa.etf.suds.service.OsumnjiceniService;
 import ba.unsa.etf.suds.service.SlucajService;
@@ -68,7 +68,7 @@ class SlucajControllerRbacTest {
         request.setDrzava("BiH");
         request.setTim(List.of());
 
-        Slucaj expectedSlucaj = new Slucaj();
+        SlucajListDTO expectedSlucaj = new SlucajListDTO();
         expectedSlucaj.setSlucajId(1L);
         expectedSlucaj.setBrojSlucaja("SLU-2026-001");
 
@@ -88,7 +88,7 @@ class SlucajControllerRbacTest {
         request.setStanicaId(1L);
         request.setBrojSlucaja("SLU-2026-002");
 
-        Slucaj slucaj = new Slucaj();
+        SlucajListDTO slucaj = new SlucajListDTO();
         slucaj.setSlucajId(2L);
         when(slucajService.kreirajSlucaj(any(), any())).thenReturn(slucaj);
 

--- a/suds/src/test/java/ba/unsa/etf/suds/service/SlucajServiceTest.java
+++ b/suds/src/test/java/ba/unsa/etf/suds/service/SlucajServiceTest.java
@@ -3,6 +3,7 @@ package ba.unsa.etf.suds.service;
 import ba.unsa.etf.suds.config.DatabaseManager;
 import ba.unsa.etf.suds.dto.IzvjestajDTO;
 import ba.unsa.etf.suds.dto.KreirajSlucajRequest;
+import ba.unsa.etf.suds.dto.SlucajListDTO;
 import ba.unsa.etf.suds.model.Slucaj;
 import ba.unsa.etf.suds.repository.AdresaRepository;
 import ba.unsa.etf.suds.repository.IzvjestajRepository;
@@ -92,12 +93,19 @@ class SlucajServiceTest {
         when(adresaRepository.saveWithConnection(any(Connection.class), any())).thenReturn(2L);
         when(slucajRepository.saveWithConnection(any(Connection.class), any())).thenReturn(2L);
 
-        Slucaj result = slucajService.kreirajSlucaj(request, 1L);
+        SlucajListDTO expectedDto = new SlucajListDTO();
+        expectedDto.setSlucajId(2L);
+        expectedDto.setBrojSlucaja("SLU-2026-002");
+        when(slucajRepository.findByIdWithVoditelj(2L)).thenReturn(Optional.of(expectedDto));
+
+        SlucajListDTO result = slucajService.kreirajSlucaj(request, 1L);
 
         assertNotNull(result);
-        assertEquals(2L, getField(result, "slucajId"));
+        assertEquals(2L, result.getSlucajId());
+        assertEquals("SLU-2026-002", result.getBrojSlucaja());
         verify(mockConnection, times(1)).commit();
         verify(mockConnection, never()).rollback();
+        verify(slucajRepository).findByIdWithVoditelj(2L);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #13 — Case creation success message displayed `Slučaj undefined je uspješno kreiran` instead of the actual case name.

## Root Cause

`SlucajController.kreirajSlucaj()` returned the raw `Slucaj` model object which serializes to **camelCase** JSON (`brojSlucaja`, `slucajId`). The frontend expected **snake_case** fields (`broj_slucaja`, `slucaj_id`) because all other case endpoints return `SlucajListDTO` which uses `@JsonNaming(SnakeCaseStrategy)`.

## Changes

- **`SlucajService.java`** — Changed `kreirajSlucaj()` return type from `Slucaj` to `SlucajListDTO`; calls `findByIdWithVoditelj()` after commit to build the DTO with leader name
- **`SlucajController.java`** — Updated variable type from `Slucaj` to `SlucajListDTO`
- **`CaseList.jsx`** — Removed `voditelj_slucaja_id` check (field doesn't exist on `SlucajListDTO`)
- **`SlucajServiceTest.java`** — Updated mocks for `findByIdWithVoditelj` and assertions for `SlucajListDTO`
- **`SlucajControllerRbacTest.java`** — Updated `Slucaj` to `SlucajListDTO` in mock returns

## Verification

- ✅ `mvn clean install` — 66 tests pass, 0 failures
- ✅ `npm run build` — Vite build success
- ✅ Manual browser QA — Created case "TEST-2026-QA2", success message correctly shows: `Slučaj "TEST-2026-QA2" je uspješno kreiran.`