### PR TITLE
docs: comprehensive project documentation + codebase Javadoc (closes #27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,162 @@
-# Advanced Databases - JDBC Project
+# SUDS — Sistem za Upravljanje Dokazima i Slučajevima
 
-This repository contains a Java-based backend application developed for the **Advanced Databases** course. The project strictly focuses on direct database interaction using the **pure JDBC API** (without ORM frameworks like Hibernate or Spring Data JPA).
+**Evidence and Case Management System** — a full-stack web application for
+law-enforcement agencies, digitalizing criminal cases, suspects, witnesses and
+the legally-critical **chain of custody** for forensic evidence.
 
-## 🚓 About The Project (SUDS)
+Built for the **Napredne baze podataka** (Advanced Databases) course at ETF
+Sarajevo, the backend talks to Oracle via **pure JDBC** — no Hibernate, no
+Spring Data JPA.
 
-**SUDS (Sistem za upravljanje dokazima i slučajevima / Evidence and Case Management System)** is a comprehensive backend system designed for law enforcement agencies. It digitalizes the tracking of criminal cases, suspects, and the critical chain of custody for forensic evidence.
+> 📚 **Full documentation lives in the
+> [project wiki](https://github.com/Zukic98/NBP-project/wiki).**
 
-### Key Features
-* **Case Management:** Create and track criminal cases, assigning lead investigators.
-* **Suspect Tracking:** Register suspects and link them to specific cases and criminal offenses.
-* **Evidence & Chain of Custody:** Log physical evidence and strictly track its movement (who handed it over, who received it, and when) to maintain legal integrity.
-* **Personnel Management:** View and manage police station staff and forensic experts.
+______________________________________________________________________
 
-## 🛠️ Tech Stack
-* **Language:** Java 21
-* **Framework:** Spring Boot 4.0.4 (Web & REST API only)
-* **Database Access:** Pure JDBC (`java.sql.*`)
-* **Database:** Oracle Database (`ojdbc11`)
-* **Build Tool:** Maven
+## 🚓 About the project
+
+SUDS solves three concrete problems for police stations:
+
+1. **Fragmented case data** — cases, witnesses, suspects and evidence used to
+   live in separate paper binders. SUDS keeps everything related to a case under
+   one record and joins the rest by foreign key.
+2. **Untraceable evidence handovers** — every transfer between officers, lab and
+   depot is recorded as an immutable `LANAC_NADZORA` row with sender, receiver,
+   station, timestamp and confirmation status. See
+   **[Chain of Custody](https://github.com/Zukic98/NBP-project/wiki/09-Chain-of-Custody)**.
+3. **Inconsistent role responsibilities** — four roles (`SEF_STANICE`,
+   `INSPEKTOR`, `POLICAJAC`, `FORENZIČAR`) enforced by Spring Security and the
+   React UI.
+
+## ✨ Key features
+
+- **Case management** — create, assign lead investigator, generate per-case PDF
+  report (iText 7).
+- **Suspect tracking** — register suspects with photos, link to one or more
+  cases.
+- **Evidence & chain of custody** — handovers require explicit confirmation by
+  the receiver.
+- **Forensic workflow** — `FORENZIČAR`-only reports tied to specific evidence.
+- **Personnel management** — `SEF_STANICE` onboards and deactivates employees in
+  their station.
+- **Live API docs** — Swagger UI at `/swagger-ui.html` (SpringDoc OpenAPI 2.1).
+
+## 🛠️ Tech stack
+
+| Layer       | Stack                                                             |
+| ----------- | ----------------------------------------------------------------- |
+| Frontend    | React 19 + Vite 5 + TailwindCSS 3 + axios                         |
+| Backend     | Java 21 + Spring Boot 4.0.4 + Spring Security + JWT (jjwt 0.12.6) |
+| Persistence | Pure JDBC (`java.sql.*`) over Oracle 19c (`ojdbc11`)              |
+| Reporting   | iText 7 (server-side PDF), html2pdf.js (client-side)              |
+| API docs    | SpringDoc OpenAPI 2.1.0                                           |
+| Build tools | Maven, Vite                                                       |
 
 ## 🏛️ Architecture
 
-The project strictly follows a **3-Tier Architecture** to separate concerns:
-1. **Controllers (REST API):** Handle incoming HTTP requests and return JSON responses.
-2. **Services (Business Logic):** Contain all validation and business rules.
-3. **Repositories (Data Access):** The *only* layer that interacts with the Oracle database using raw SQL queries (`PreparedStatement`, `ResultSet`).
-* *Note: Data Transfer Objects (DTOs) are used to format data for the frontend, while Models represent raw database tables.*
+A classic 3-tier backend (`controller` → `service` → `repository`) plus a
+stateless React SPA. Authentication is JWT (HS256) carrying `user_id`,
+`role_name` and `stanica_id` claims.
 
-## 📥 Getting Started
+```text
+nbp-project/
+├── suds/        ← Spring Boot backend (port 8080)
+└── frontend/    ← React + Vite SPA (port 5173 in dev)
+```
 
-To get a local copy up and running, follow these steps:
+For full diagrams, see
+**[Architecture](https://github.com/Zukic98/NBP-project/wiki/03-Architecture)**.
 
-### 1. Prerequisites
-* Java Development Kit (JDK 17 or 21) installed.
-* Maven installed.
-* An active connection to the Oracle Database.
+## 📥 Quick start
 
-### 2. Clone the repository
+### Prerequisites
+
+- JDK 21 (JDK 26 also works)
+- Maven 3.9+
+- Node.js 18+
+- An Oracle DB account (course server: `ora-02.db.lab.etf.unsa.ba:1521/ETFDB`)
+
+### 1. Clone
+
 ```bash
-git clone [https://github.com/Zukic98/NBP-project.git](https://github.com/Zukic98/NBP-project.git)
+git clone https://github.com/Zukic98/NBP-project.git
 cd NBP-project
 ```
 
-### 3. Configure the Database Connection
-Do not commit your real database credentials to GitHub! 
-Create or modify the `src/main/resources/application.yml` file with your Oracle database details:
+### 2. Configure & run the backend
+
+Edit `suds/src/main/resources/application.yml`:
 
 ```yaml
 server:
   port: 8080
 
 db:
-  url: jdbc:oracle:thin:@//YOUR_HOST:PORT/YOUR_SERVICE_NAME
+  url: jdbc:oracle:thin:@//YOUR_HOST:1521/YOUR_SERVICE_NAME
   username: YOUR_USERNAME
   password: YOUR_PASSWORD
 
 jwt:
-  secret: JWT_SECRET
-  expiration-ms: EXPIRATION_MS
+  secret: change-me-to-a-long-random-256-bit-string
+  expiration-ms: 86400000
 ```
 
-### 4. Build and Run
-You can run the application directly from your IDE (e.g., IntelliJ IDEA) by executing the `SudsApplication.java` main class, or via the terminal using Maven:
+Then:
 
 ```bash
+cd suds
 mvn clean install
 mvn spring-boot:run
 ```
-The REST API will be available at `http://localhost:8080`.
+
+API: <http://localhost:8080> Swagger UI: <http://localhost:8080/swagger-ui.html>
+
+### 3. Configure & run the frontend
+
+```bash
+cd frontend
+cp .env.example .env       # rename VITE_API_BASE_URL → VITE_API_URL inside .env
+npm install
+npm run dev
+```
+
+SPA: <http://localhost:5173>
+
+> Detailed step-by-step instructions, including the first-run bootstrap flow,
+> are in the
+> **[Setup Guide](https://github.com/Zukic98/NBP-project/wiki/04-Setup-Guide)**.
+
+## 📖 Documentation
+
+The full project documentation lives in the
+**[GitHub Wiki](https://github.com/Zukic98/NBP-project/wiki)**:
+
+| Section                                                                                                       | Content                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [About the Project](https://github.com/Zukic98/NBP-project/wiki/01-About-The-Project)                         | What SUDS does and why                                                                                                                                                                                                                                                                                                                                               |
+| [Tech Stack](https://github.com/Zukic98/NBP-project/wiki/02-Tech-Stack)                                       | Every dependency, version, purpose                                                                                                                                                                                                                                                                                                                                   |
+| [Architecture](https://github.com/Zukic98/NBP-project/wiki/03-Architecture)                                   | System diagrams (Mermaid), 3-tier, request lifecycle                                                                                                                                                                                                                                                                                                                 |
+| [Setup Guide](https://github.com/Zukic98/NBP-project/wiki/04-Setup-Guide)                                     | Prereqs, step-by-step install                                                                                                                                                                                                                                                                                                                                        |
+| [Configuration](https://github.com/Zukic98/NBP-project/wiki/05-Configuration)                                 | Every config key explained                                                                                                                                                                                                                                                                                                                                           |
+| [Database Schema](https://github.com/Zukic98/NBP-project/wiki/06-Database-Schema)                             | Mermaid ER diagram + every table                                                                                                                                                                                                                                                                                                                                     |
+| [API Reference](https://github.com/Zukic98/NBP-project/wiki/07-API-Reference)                                 | Every endpoint, examples, status codes                                                                                                                                                                                                                                                                                                                               |
+| [Authentication & Authorization](https://github.com/Zukic98/NBP-project/wiki/08-Authentication-Authorization) | JWT claims, login flow, role rules                                                                                                                                                                                                                                                                                                                                   |
+| [Chain of Custody](https://github.com/Zukic98/NBP-project/wiki/09-Chain-of-Custody)                           | The core domain workflow                                                                                                                                                                                                                                                                                                                                             |
+| [Frontend Architecture](https://github.com/Zukic98/NBP-project/wiki/10-Frontend-Architecture)                 | React component tree                                                                                                                                                                                                                                                                                                                                                 |
+| User guides                                                                                                   | Per-role walkthroughs ([Šef stanice](https://github.com/Zukic98/NBP-project/wiki/11-User-Guide-Sef-Stanice), [Inspektor](https://github.com/Zukic98/NBP-project/wiki/12-User-Guide-Inspektor), [Policajac](https://github.com/Zukic98/NBP-project/wiki/13-User-Guide-Policajac), [Forenzičar](https://github.com/Zukic98/NBP-project/wiki/14-User-Guide-Forenzicar)) |
+
+## 🧪 Live API documentation
+
+When the backend is running, SpringDoc serves:
+
+- **Swagger UI:** <http://localhost:8080/swagger-ui.html> — interactive,
+  click-to-call.
+- **OpenAPI JSON:** <http://localhost:8080/v3/api-docs> — machine-readable,
+  ready for Postman / client codegen.
+
+Both are public (no token required) and authenticated operations have an
+*Authorize* button that takes a JWT.
+
+## 📜 License
+
+See [LICENSE](LICENSE).

--- a/suds/pom.xml
+++ b/suds/pom.xml
@@ -129,6 +129,27 @@
 					<argLine>-XX:+EnableDynamicAgentLoading</argLine>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.11.2</version>
+				<configuration>
+					<source>21</source>
+					<encoding>UTF-8</encoding>
+					<docencoding>UTF-8</docencoding>
+					<charset>UTF-8</charset>
+					<doctitle>SUDS API Documentation</doctitle>
+					<windowtitle>SUDS — Sistem za upravljanje dokazima i slučajevima</windowtitle>
+					<show>protected</show>
+					<failOnError>false</failOnError>
+					<failOnWarnings>false</failOnWarnings>
+					<doclint>none</doclint>
+					<quiet>true</quiet>
+					<additionalJOptions>
+						<additionalJOption>-Xdoclint:none</additionalJOption>
+					</additionalJOptions>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/suds/src/main/java/ba/unsa/etf/suds/SudsApplication.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/SudsApplication.java
@@ -4,9 +4,22 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
 
+/**
+ * Glavna ulazna tačka SUDS Spring Boot aplikacije.
+ * <p>
+ * Pokreće cijeli aplikacijski kontekst, uključujući sve komponente unutar
+ * paketa {@code ba.unsa.etf.suds} (kontroleri, servisi, repozitoriji,
+ * sigurnosna konfiguracija i upravljanje bazom podataka).
+ * </p>
+ */
 @SpringBootApplication
 @ComponentScan(basePackages = "ba.unsa.etf.suds") 
 public class SudsApplication {
+    /**
+     * Pokreće Spring Boot aplikaciju.
+     *
+     * @param args argumenti komandne linije proslijeđeni JVM-u
+     */
     public static void main(String[] args) {
         SpringApplication.run(SudsApplication.class, args);
     }

--- a/suds/src/main/java/ba/unsa/etf/suds/config/DatabaseManager.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/config/DatabaseManager.java
@@ -7,6 +7,25 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
+/**
+ * Fabrika JDBC konekcija prema Oracle bazi podataka.
+ * <p>
+ * Svaki poziv metode {@link #getConnection()} kreira <strong>novu</strong>
+ * konekciju putem {@link DriverManager} — nema connection pool-a.
+ * Pozivalac je vlasnik konekcije i <strong>mora</strong> je zatvoriti,
+ * idealno putem {@code try-with-resources} bloka:
+ * </p>
+ * <pre>{@code
+ * try (Connection conn = dbManager.getConnection();
+ *      PreparedStatement stmt = conn.prepareStatement(sql)) {
+ *     // ...
+ * }
+ * }</pre>
+ * <p>
+ * Parametri konekcije ({@code db.url}, {@code db.username}, {@code db.password})
+ * čitaju se iz {@code application.yml}.
+ * </p>
+ */
 @Configuration
 public class DatabaseManager {
 
@@ -21,8 +40,16 @@ public class DatabaseManager {
     private String password;
 
     /**
-     * Open and return new clean JDBC connection to Oracle database.
-     * IMPORTANT: Person who calls this method must close connection.
+     * Otvara i vraća novu JDBC konekciju prema Oracle bazi podataka.
+     * <p>
+     * <strong>Pravilo vlasništva:</strong> pozivalac je odgovoran za zatvaranje
+     * vraćene konekcije. Preporučuje se upotreba {@code try-with-resources}
+     * kako bi se konekcija sigurno oslobodila čak i u slučaju iznimke.
+     * </p>
+     *
+     * @return aktivna {@link Connection} prema Oracle bazi
+     * @throws SQLException ako Oracle JDBC drajver nije pronađen na classpath-u
+     *                      ili ako konekcija ne može biti uspostavljena
      */
     public Connection getConnection() throws SQLException {
         try {

--- a/suds/src/main/java/ba/unsa/etf/suds/config/OpenApiConfig.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/config/OpenApiConfig.java
@@ -8,10 +8,35 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Konfiguracija SpringDoc OpenAPI (Swagger UI) za SUDS aplikaciju.
+ * <p>
+ * Registruje globalni {@code bearerAuth} JWT sigurnosni shemu koji se
+ * automatski propagira na sve operacije u Swagger UI-u. Korisnik može
+ * unijeti JWT token putem dugmeta <em>Authorize</em> i sve naredne
+ * zahtjeve Swagger UI šalje s odgovarajućim {@code Authorization: Bearer ...}
+ * zaglavljem.
+ * </p>
+ */
 @Configuration
 public class OpenApiConfig {
 
     @Bean
+    /**
+     * Kreira prilagođenu {@link OpenAPI} konfiguraciju s JWT sigurnosnom shemom.
+     * <p>
+     * Definiše:
+     * <ul>
+     *   <li>Metapodatke API-ja (naslov, verzija, opis);</li>
+     *   <li>Globalni sigurnosni zahtjev {@code bearerAuth} koji se primjenjuje
+     *       na sve endpoint-e;</li>
+     *   <li>HTTP Bearer sigurnosnu shemu s formatom {@code JWT} — Swagger UI
+     *       prikazuje polje za unos tokena u dijalogu <em>Authorize</em>.</li>
+     * </ul>
+     * </p>
+     *
+     * @return konfigurisana {@link OpenAPI} instanca
+     */
     public OpenAPI customOpenAPI() {
         final String securitySchemeName = "bearerAuth";
         

--- a/suds/src/main/java/ba/unsa/etf/suds/config/SecurityConfig.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/config/SecurityConfig.java
@@ -11,17 +11,51 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+/**
+ * Centralna Spring Security konfiguracija SUDS aplikacije.
+ * <p>
+ * Aktivira web sigurnost ({@code @EnableWebSecurity}) i metod-nivo sigurnost
+ * ({@code @EnableMethodSecurity}) kako bi {@code @PreAuthorize} anotacije
+ * na kontrolerima funkcionisale. Koristi isključivo JWT autentifikaciju —
+ * nema HTTP sesija ni form-based prijave.
+ * </p>
+ */
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
 public class SecurityConfig {
     private final JwtFilter jwtFilter;
 
+    /**
+     * Kreira instancu konfiguracije uz injekciju JWT filtera.
+     *
+     * @param jwtFilter filter koji parsira i validira JWT token iz svakog zahtjeva
+     */
     public SecurityConfig(JwtFilter jwtFilter) {
         this.jwtFilter = jwtFilter;
     }
 
     @Bean
+    /**
+     * Konfiguriše glavni Spring Security filter chain:
+     * <ul>
+     *   <li>Onemogućuje CSRF (stateless API);</li>
+     *   <li>Postavlja CORS za frontend na {@code http://localhost:5173};</li>
+     *   <li>Stateless session policy (nema {@code HttpSession}-a);</li>
+     *   <li>Whitelist javnih endpoint-a: {@code /api/auth/login},
+     *       {@code /api/stanice/register}, {@code /api/adrese},
+     *       Swagger UI i OpenAPI JSON putanje, te {@code /error};</li>
+     *   <li>Endpoint-i za fotografije dokaza i osumnjičenih dostupni svim
+     *       autentifikovanim korisnicima;</li>
+     *   <li>Sve ostalo zahtijeva autentifikaciju;</li>
+     *   <li>Ubacuje {@link JwtFilter} prije
+     *       {@link UsernamePasswordAuthenticationFilter}.</li>
+     * </ul>
+     *
+     * @param http Spring Security konfiguracijski builder
+     * @return izgrađen {@link SecurityFilterChain}
+     * @throws Exception ako konfiguracija ne uspije
+     */
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
@@ -56,11 +90,27 @@ public class SecurityConfig {
     }
 
     @Bean
+    /**
+     * Kreira {@link BCryptPasswordEncoder} bean za hashiranje lozinki.
+     *
+     * @return instanca BCrypt enkodera sa podrazumijevanim faktorom snage (10)
+     */
     public BCryptPasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
     @Bean
+    /**
+     * Konfiguriše CORS politiku za cijelu aplikaciju.
+     * <p>
+     * Dozvoljava zahtjeve isključivo s frontend origin-a
+     * {@code http://localhost:5173}, uz podršku za sve standardne HTTP metode
+     * i zaglavlja {@code Authorization} i {@code Content-Type}.
+     * Credentials (kolačići, Authorization zaglavlje) su dozvoljeni.
+     * </p>
+     *
+     * @return {@link org.springframework.web.cors.CorsConfigurationSource} registrovan za sve putanje ({@code /**})
+     */
     public org.springframework.web.cors.CorsConfigurationSource corsConfigurationSource() {
         org.springframework.web.cors.CorsConfiguration configuration = new org.springframework.web.cors.CorsConfiguration();
         configuration.setAllowedOrigins(java.util.List.of("http://localhost:5173"));
@@ -74,6 +124,17 @@ public class SecurityConfig {
     }
 
     @Bean
+    /**
+     * Stub {@link org.springframework.security.core.userdetails.UserDetailsService} bean.
+     * <p>
+     * SUDS koristi isključivo JWT autentifikaciju, pa standardni Spring Security
+     * mehanizam učitavanja korisnika po korisničkom imenu nije potreban.
+     * Svaki poziv baca {@link org.springframework.security.core.userdetails.UsernameNotFoundException}
+     * kako bi se spriječilo nenamjerno korištenje form-based prijave.
+     * </p>
+     *
+     * @return {@link org.springframework.security.core.userdetails.UserDetailsService} koji uvijek baca iznimku
+     */
     public org.springframework.security.core.userdetails.UserDetailsService userDetailsService() {
         return username -> {
             throw new org.springframework.security.core.userdetails.UsernameNotFoundException("Use JWT");

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/AdresaController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/AdresaController.java
@@ -11,6 +11,12 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * REST kontroler za upravljanje adresama.
+ *
+ * <p>Bazna putanja: {@code /api/adrese}. Delegira sve operacije servisu
+ * {@code AdresaService}. Endpoint je dostupan svim autentifikovanim korisnicima.
+ */
 @RestController
 @RequestMapping("/api/adrese")
 @Tag(name = "Adrese", description = "Upravljanje adresama")
@@ -18,10 +24,16 @@ public class AdresaController {
 
     private final AdresaService adresaService;
 
+    /** Konstruktorska injekcija servisa za adrese. */
     public AdresaController(AdresaService adresaService) {
         this.adresaService = adresaService;
     }
 
+    /**
+     * GET /api/adrese - dohvata sve adrese u sistemu.
+     *
+     * @return 200 + lista svih adresa
+     */
     // GET zahtjev za sve adrese (Pristup: http://localhost:8080/api/adrese)
     @GetMapping
     @Operation(summary = "Dohvati sve adrese")
@@ -30,6 +42,12 @@ public class AdresaController {
         return ResponseEntity.ok(adresaService.getAllAdrese());
     }
 
+    /**
+     * POST /api/adrese - kreira novu adresu.
+     *
+     * @param adresa tijelo zahtjeva sa podacima adrese
+     * @return 200 + kreirana adresa, 400 ako su podaci neispravni, 500 pri grešci na serveru
+     */
     // POST zahtjev za novu adresu
     @PostMapping
     @Operation(summary = "Kreiraj novu adresu")

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/AuthController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/AuthController.java
@@ -15,6 +15,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * REST kontroler za autentifikaciju (prijava, odjava, vlastita lozinka).
+ *
+ * <p>Bazna putanja: {@code /api/auth}. Endpoint za prijavu ({@code POST /login})
+ * je javan; ostali zahtijevaju validan JWT token u {@code Authorization} headeru.
+ * Delegira logiku autentifikacije servisu {@code AuthService}, a upravljanje
+ * lozinkama servisu {@code UposlenikService}.
+ */
 @RestController
 @RequestMapping("/api/auth")
 @Tag(name = "Autentifikacija", description = "Prijava, odjava i upravljanje lozinkama")
@@ -24,12 +32,24 @@ public class AuthController {
     private final UposlenikService uposlenikService;
     private final JwtUtil jwtUtil;
 
+    /** Konstruktorska injekcija servisa za autentifikaciju, uposlenike i JWT pomoćnih metoda. */
     public AuthController(AuthService authService, UposlenikService uposlenikService, JwtUtil jwtUtil) {
         this.authService = authService;
         this.uposlenikService = uposlenikService;
         this.jwtUtil = jwtUtil;
     }
 
+    /**
+     * POST /api/auth/login - prijava korisnika.
+     *
+     * <p>Javan endpoint (ne zahtijeva token). Validira kombinaciju email/brojZnacke/lozinka
+     * i u slučaju uspjeha vraća potpisani JWT token.
+     *
+     * @param loginRequest tijelo zahtjeva sa kredencijalima korisnika
+     * @return 200 + {@link LoginResponse} sa JWT tokenom ako je prijava uspješna,
+     *         401 ako su kredencijali neispravni,
+     *         403 ako je korisnički račun deaktiviran
+     */
     @PostMapping("/login")
     @Operation(summary = "Prijava korisnika")
     @ApiResponses(value = {
@@ -49,6 +69,12 @@ public class AuthController {
         }
     }
 
+    /**
+     * POST /api/auth/logout - odjava trenutnog korisnika i stavljanje tokena na crnu listu.
+     *
+     * @param token Authorization header u obliku {@code "Bearer <jwt>"}
+     * @return 200 sa potvrdnom porukom o uspješnoj odjavi
+     */
     @PostMapping("/logout")
     @Operation(summary = "Odjava korisnika")
     @ApiResponse(responseCode = "200", description = "Uspješna odjava")
@@ -57,6 +83,16 @@ public class AuthController {
         return ResponseEntity.ok("Uspješno ste se odjavili.");
     }
 
+    /**
+     * PUT /api/auth/promijeni-lozinku - promjena vlastite lozinke prijavljenog korisnika.
+     *
+     * <p>Identitet korisnika se utvrđuje iz JWT tokena putem {@code JwtUtil.extractUserId}.
+     * Tijelo zahtjeva mora sadržavati polja {@code staraLozinka} i {@code novaLozinka}.
+     *
+     * @param request     mapa sa ključevima {@code staraLozinka} i {@code novaLozinka}
+     * @param httpRequest HTTP zahtjev iz kojeg se izvlači JWT token
+     * @return 200 sa potvrdnom porukom, 400 ako stara lozinka nije ispravna ili su podaci nevalidni
+     */
     @PutMapping("/promijeni-lozinku")
     @Operation(summary = "Promijeni vlastitu lozinku")
     @ApiResponses(value = {
@@ -74,6 +110,7 @@ public class AuthController {
         }
     }
 
+    /** Pomoćna metoda — izvlači čist JWT iz {@code Authorization} headera (uklanja prefiks "Bearer "). */
     private String extractToken(HttpServletRequest request) {
         String authHeader = request.getHeader("Authorization");
         if (authHeader != null && authHeader.startsWith("Bearer ")) {

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/DashboardController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/DashboardController.java
@@ -10,6 +10,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * REST kontroler za korisničke informacije prijavljenog korisnika.
+ *
+ * <p>Bazna putanja: {@code /api/dashboard}. Identitet korisnika se utvrđuje
+ * iz {@code SecurityContextHolder} (principal je userId kao String).
+ * Delegira dohvat profila repozitoriju {@code UposlenikRepository}.
+ */
 @RestController
 @RequestMapping("/api/dashboard")
 @Tag(name = "Dashboard", description = "Korisničke informacije")
@@ -18,11 +25,21 @@ public class DashboardController {
     private final UposlenikRepository uposlenikRepository;
     private final JwtUtil jwtUtil;
 
+    /** Konstruktorska injekcija repozitorija uposlenika i JWT pomoćnih metoda. */
     public DashboardController(UposlenikRepository uposlenikRepository, JwtUtil jwtUtil) {
         this.uposlenikRepository = uposlenikRepository;
         this.jwtUtil = jwtUtil;
     }
 
+/**
+ * GET /api/dashboard/me - dohvata profil trenutno prijavljenog korisnika.
+ *
+ * <p>Identitet se čita iz {@code SecurityContextHolder} (principal = userId kao String).
+ * Vraća {@link UposlenikDTO} sa svim podacima profila uposlenika.
+ *
+ * @return 200 + {@link UposlenikDTO} profil prijavljenog korisnika,
+ *         401 ako korisnik nije autentifikovan ili token nije validan
+ */
 @GetMapping("/me")
 @Operation(summary = "Dohvati profil prijavljenog korisnika")
 @ApiResponses(value = {

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/DokazController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/DokazController.java
@@ -17,6 +17,13 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * REST kontroler za upravljanje dokazima vezanim za slučajeve.
+ *
+ * <p>Bazna putanja: {@code /api}. Pruža operacije za dohvat, kreiranje i ažuriranje
+ * dokaza, kao i pregled lanca nadzora. Delegira sve operacije servisu {@code DokazService}.
+ * Identitet korisnika se čita iz {@code SecurityContextHolder} (principal = userId kao String).
+ */
 @RestController
 @RequestMapping("/api")
 @Tag(name = "Dokazi", description = "Upravljanje dokazima")
@@ -24,10 +31,18 @@ public class DokazController {
 
     private final DokazService dokazService;
 
+    /** Konstruktorska injekcija servisa za dokaze. */
     public DokazController(DokazService dokazService) {
         this.dokazService = dokazService;
     }
 
+    /**
+     * GET /api/slucajevi/{caseId}/dokazi - dohvata sve dokaze za određeni slučaj.
+     *
+     * @param caseId identifikator slučaja
+     * @return 200 + lista {@link DokazListDTO} za dati slučaj,
+     *         500 pri grešci na serveru
+     */
     @GetMapping("/slucajevi/{caseId}/dokazi")
     @Operation(summary = "Dohvati dokaze za slučaj")
     @ApiResponses(value = {
@@ -42,6 +57,17 @@ public class DokazController {
         }
     }
 
+    /**
+     * POST /api/slucajevi/{caseId}/dokazi - kreira novi dokaz za određeni slučaj.
+     *
+     * <p>Identitet kreatora se čita iz {@code SecurityContextHolder} (principal = userId).
+     *
+     * @param caseId  identifikator slučaja
+     * @param request tijelo zahtjeva sa podacima novog dokaza
+     * @return 201 + kreirani {@link DokazListDTO},
+     *         404 ako slučaj nije pronađen,
+     *         500 pri grešci na serveru
+     */
     @PostMapping("/slucajevi/{caseId}/dokazi")
     @Operation(summary = "Kreiraj novi dokaz za slučaj")
     @ApiResponses(value = {
@@ -67,6 +93,16 @@ public class DokazController {
         }
     }
 
+    /**
+     * GET /api/dokazi/{id}/stanje - dohvata trenutno stanje dokaza.
+     *
+     * <p>Identitet korisnika se čita iz {@code SecurityContextHolder} (principal = userId).
+     *
+     * @param dokazId identifikator dokaza
+     * @return 200 + {@link DokazStanjeDTO} sa stanjem dokaza,
+     *         404 ako dokaz nije pronađen,
+     *         500 pri grešci na serveru
+     */
     @GetMapping("/dokazi/{id}/stanje")
     @Operation(summary = "Dohvati stanje dokaza")
     @ApiResponses(value = {
@@ -89,6 +125,13 @@ public class DokazController {
         }
     }
 
+    /**
+     * GET /api/dokazi/{id}/lanac - dohvata kompletan lanac nadzora za dokaz.
+     *
+     * @param dokazId identifikator dokaza
+     * @return 200 + mapa sa ključem {@code "lanac"} i listom {@link LanacDetaljiDTO},
+     *         500 pri grešci na serveru
+     */
     @GetMapping("/dokazi/{id}/lanac")
     @Operation(summary = "Dohvati lanac nadzora za dokaz")
     @ApiResponses(value = {
@@ -104,6 +147,15 @@ public class DokazController {
         }
     }
 
+    /**
+     * PATCH /api/dokazi/{id}/status - ažurira status dokaza.
+     *
+     * @param dokazId identifikator dokaza
+     * @param request tijelo zahtjeva sa novim statusom
+     * @return 200 + poruka o uspješnom ažuriranju,
+     *         404 ako dokaz nije pronađen,
+     *         500 pri grešci na serveru
+     */
     @PatchMapping("/dokazi/{id}/status")
     @Operation(summary = "Ažuriraj status dokaza")
     @ApiResponses(value = {

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/DokazFotografijaController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/DokazFotografijaController.java
@@ -12,6 +12,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * REST kontroler za upravljanje fotografijama dokaza.
+ *
+ * <p>Bazna putanja: {@code /api/dokazi}. Podržava dohvat i upload fotografija
+ * vezanih za dokaze. Upload je multipart/form-data zahtjev; jednom dodana fotografija
+ * ostaje trajno (nema brisanja). Identitet korisnika se izvlači iz JWT tokena
+ * putem {@code JwtUtil.extractUserId}.
+ */
 @RestController
 @RequestMapping("/api/dokazi")
 public class DokazFotografijaController {
@@ -19,6 +27,7 @@ public class DokazFotografijaController {
     private final DokazFotografijaService dokazFotografijaService;
     private final JwtUtil jwtUtil;
 
+    /** Konstruktorska injekcija servisa za fotografije dokaza i JWT pomoćnih metoda. */
     public DokazFotografijaController(DokazFotografijaService dokazFotografijaService,
                                       JwtUtil jwtUtil) {
         this.dokazFotografijaService = dokazFotografijaService;
@@ -26,8 +35,13 @@ public class DokazFotografijaController {
     }
 
     /**
-     * GET /api/dokazi/{dokazId}/fotografije
-     * Dobavljanje svih fotografija za dokaz
+     * GET /api/dokazi/{dokazId}/fotografije - dohvata sve fotografije za određeni dokaz.
+     *
+     * <p>Fotografije se vraćaju kao Base64-kodirani stringovi unutar {@link DokazFotografijaDTO}.
+     *
+     * @param dokazId identifikator dokaza
+     * @return 200 + lista {@link DokazFotografijaDTO},
+     *         500 pri grešci na serveru
      */
     // U DokazFotografijaController.java
     @GetMapping("/{dokazId}/fotografije")
@@ -48,9 +62,20 @@ public class DokazFotografijaController {
     }
 
     /**
-     * POST /api/dokazi/{dokazId}/fotografije
-     * Upload fotografije za dokaz
-     * Samo INSERT dozvoljen - jednom dodana fotografija ostaje trajno
+     * POST /api/dokazi/{dokazId}/fotografije - upload fotografije za određeni dokaz.
+     *
+     * <p>Multipart/form-data zahtjev. Dozvoljeni formati: JPEG, PNG, GIF, WebP.
+     * Maksimalna veličina fajla: 10 MB. Identitet korisnika se izvlači iz JWT tokena
+     * putem {@code JwtUtil.extractUserId}. Jednom dodana fotografija ostaje trajno.
+     *
+     * @param dokazId   identifikator dokaza
+     * @param file      fotografija kao multipart fajl
+     * @param redniBroj opcionalni redni broj fotografije
+     * @param opis      opcionalni opis fotografije
+     * @param token     Authorization header u obliku {@code "Bearer <jwt>"}
+     * @return 201 + poruka o uspješnom uploadu,
+     *         400 ako je format ili veličina fajla neispravna,
+     *         500 pri grešci na serveru
      */
     @PostMapping("/{dokazId}/fotografije")
     public ResponseEntity<?> uploadFotografiju(@PathVariable Long dokazId,

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/ForenzickiIzvjestajController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/ForenzickiIzvjestajController.java
@@ -7,16 +7,34 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * REST kontroler za upravljanje forenzičkim izvještajima.
+ *
+ * <p>Bazna putanja: {@code /api/forenzicki-izvjestaji}. Kreiranje i ažuriranje
+ * izvještaja zahtijeva ulogu {@code FORENZIČAR}. Dohvat izvještaja po dokazu
+ * dostupan je svim autentifikovanim korisnicima. Delegira sve operacije
+ * servisu {@code ForenzickiIzvjestajService}.
+ */
 @RestController
 @RequestMapping("/api/forenzicki-izvjestaji")
 @Tag(name = "Forenzički izvještaji")
 public class ForenzickiIzvjestajController {
     private final ForenzickiIzvjestajService service;
 
+    /** Konstruktorska injekcija servisa za forenzičke izvještaje. */
     public ForenzickiIzvjestajController(ForenzickiIzvjestajService service) {
         this.service = service;
     }
 
+    /**
+     * POST /api/forenzicki-izvjestaji - kreira novi forenzički izvještaj.
+     *
+     * <p>Samo {@code FORENZIČAR} može kreirati izvještaje ({@code @PreAuthorize("hasRole('FORENZICAR')")}).
+     *
+     * @param izvjestaj tijelo zahtjeva sa podacima novog izvještaja
+     * @return 200 + kreirani {@link ForenzickiIzvjestaj},
+     *         403 ako korisnik nema ulogu FORENZIČAR
+     */
     @PostMapping
     @PreAuthorize("hasRole('FORENZICAR')")
     public ResponseEntity<ForenzickiIzvjestaj> kreiraj(@RequestBody ForenzickiIzvjestaj izvjestaj) {
@@ -24,6 +42,13 @@ public class ForenzickiIzvjestajController {
         return ResponseEntity.ok(novi);
     }
 
+    /**
+     * GET /api/forenzicki-izvjestaji/dokaz/{id} - dohvata forenzički izvještaj za određeni dokaz.
+     *
+     * @param id identifikator dokaza
+     * @return 200 + {@link ForenzickiIzvjestaj} ako postoji,
+     *         204 ako za dati dokaz ne postoji izvještaj
+     */
     @GetMapping("/dokaz/{id}")
     public ResponseEntity<ForenzickiIzvjestaj> getByDokaz(@PathVariable Long id) {
         ForenzickiIzvjestaj izvjestaj = service.getIzvjestajZaDokaz(id);
@@ -34,6 +59,16 @@ public class ForenzickiIzvjestajController {
     return ResponseEntity.ok(izvjestaj);
     }
 
+    /**
+     * PUT /api/forenzicki-izvjestaji/{id} - ažurira postojeći forenzički izvještaj.
+     *
+     * <p>Samo {@code FORENZIČAR} može ažurirati izvještaje ({@code @PreAuthorize("hasRole('FORENZICAR')")}).
+     *
+     * @param id        identifikator izvještaja koji se ažurira
+     * @param izvjestaj tijelo zahtjeva sa novim podacima izvještaja
+     * @return 200 + ažurirani {@link ForenzickiIzvjestaj},
+     *         403 ako korisnik nema ulogu FORENZIČAR
+     */
     @PutMapping("/{id}")
     @PreAuthorize("hasRole('FORENZICAR')")
     public ResponseEntity<ForenzickiIzvjestaj> azuriraj(@PathVariable Long id, @RequestBody ForenzickiIzvjestaj izvjestaj) {

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/KrivicnoDjeloController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/KrivicnoDjeloController.java
@@ -11,16 +11,29 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * REST kontroler za upravljanje krivičnim djelima.
+ *
+ * <p>Bazna putanja: {@code /api/krivicna-djela}. Pruža CRUD operacije nad
+ * krivičnim djelima. Delegira sve operacije servisu {@code KrivicnoDjeloService}.
+ * Dostupno svim autentifikovanim korisnicima.
+ */
 @RestController
 @RequestMapping("/api/krivicna-djela")
 @Tag(name = "Krivična djela", description = "Upravljanje krivičnim djelima")
 public class KrivicnoDjeloController {
     private final KrivicnoDjeloService service;
 
+    /** Konstruktorska injekcija servisa za krivična djela. */
     public KrivicnoDjeloController(KrivicnoDjeloService service) {
         this.service = service;
     }
 
+    /**
+     * GET /api/krivicna-djela - dohvata sva krivična djela u sistemu.
+     *
+     * @return 200 + lista svih {@link KrivicnoDjelo}
+     */
     @GetMapping
     @Operation(summary = "Dohvati sva krivična djela")
     @ApiResponse(responseCode = "200", description = "Lista krivičnih djela vraćena")
@@ -28,6 +41,13 @@ public class KrivicnoDjeloController {
         return ResponseEntity.ok(service.getAll());
     }
 
+    /**
+     * GET /api/krivicna-djela/{id} - dohvata krivično djelo po ID-u.
+     *
+     * @param id identifikator krivičnog djela
+     * @return 200 + {@link KrivicnoDjelo},
+     *         404 ako krivično djelo nije pronađeno
+     */
     @GetMapping("/{id}")
     @Operation(summary = "Dohvati krivično djelo po ID-u")
     @ApiResponses(value = {
@@ -39,6 +59,13 @@ public class KrivicnoDjeloController {
     }
 
 
+    /**
+     * POST /api/krivicna-djela - kreira novo krivično djelo.
+     *
+     * @param djelo tijelo zahtjeva sa podacima novog krivičnog djela
+     * @return 201 + kreirano {@link KrivicnoDjelo},
+     *         400 ako su podaci nevalidni
+     */
     @PostMapping
     @Operation(summary = "Kreiraj novo krivično djelo")
     @ApiResponses(value = {
@@ -49,6 +76,14 @@ public class KrivicnoDjeloController {
         return ResponseEntity.status(201).body(service.create(djelo));
     }
 
+    /**
+     * PUT /api/krivicna-djela/{id} - ažurira postojeće krivično djelo.
+     *
+     * @param id   identifikator krivičnog djela koje se ažurira
+     * @param djelo tijelo zahtjeva sa novim podacima
+     * @return 200 + ažurirano {@link KrivicnoDjelo},
+     *         404 ako krivično djelo nije pronađeno
+     */
     @PutMapping("/{id}")
     @Operation(summary = "Ažuriraj postojeće krivično djelo")
     @ApiResponses(value = {
@@ -59,6 +94,13 @@ public class KrivicnoDjeloController {
         return ResponseEntity.ok(service.update(id, djelo));
     }
 
+    /**
+     * DELETE /api/krivicna-djela/{id} - briše krivično djelo.
+     *
+     * @param id identifikator krivičnog djela koje se briše
+     * @return 204 bez sadržaja,
+     *         404 ako krivično djelo nije pronađeno
+     */
     @DeleteMapping("/{id}")
     @Operation(summary = "Obriši krivično djelo")
     @ApiResponses(value = {

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/LanacNadzoraController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/LanacNadzoraController.java
@@ -13,16 +13,35 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * REST kontroler za upravljanje lancem nadzora dokaza.
+ *
+ * <p>Bazna putanja: {@code /api/lanac-nadzora}. Pruža operacije za slanje dokaza,
+ * pregled vlastitih zahtjeva, prihvatanje i potvrdu/odbijanje primopredaje.
+ * Identitet korisnika se čita iz {@code SecurityContextHolder} (principal = userId kao String).
+ * Delegira sve operacije servisu {@code LanacNadzoraService}.
+ */
 @RestController
 @RequestMapping("/api/lanac-nadzora")
 @Tag(name = "Lanac nadzora", description = "Lanac nadzora dokaza")
 public class LanacNadzoraController {
     private final LanacNadzoraService service;
 
+    /** Konstruktorska injekcija servisa za lanac nadzora. */
     public LanacNadzoraController(LanacNadzoraService service) {
         this.service = service;
     }
 
+    /**
+     * POST /api/lanac-nadzora/posalji - šalje dokaz na primopredaju.
+     *
+     * <p>Identitet pošiljaoca se čita iz {@code SecurityContextHolder} (principal = userId).
+     *
+     * @param request tijelo zahtjeva sa podacima o slanju dokaza
+     * @return 200 + kreirani {@link LanacNadzora} unos,
+     *         400 ako je zahtjev neispravan,
+     *         500 pri grešci na serveru
+     */
     @PostMapping("/posalji")
     @Operation(summary = "Pošalji dokaz na primopredaju")
     @ApiResponses(value = {
@@ -39,6 +58,13 @@ public class LanacNadzoraController {
         return ResponseEntity.ok(lanac);
     }
 
+    /**
+     * GET /api/lanac-nadzora/moji-zahtjevi - dohvata zahtjeve u lancu nadzora za prijavljenog korisnika.
+     *
+     * <p>Identitet korisnika se čita iz {@code SecurityContextHolder} (principal = userId).
+     *
+     * @return 200 + lista {@link LanacNadzora} zahtjeva vezanih za prijavljenog korisnika
+     */
     @GetMapping("/moji-zahtjevi")
     @Operation(summary = "Dohvati moje zahtjeve u lancu nadzora")
     @ApiResponse(responseCode = "200", description = "Lista zahtjeva vraćena")
@@ -50,6 +76,15 @@ public class LanacNadzoraController {
         return ResponseEntity.ok(zahtjevi);
     }
 
+    /**
+     * PUT /api/lanac-nadzora/prihvati/{id} - prihvata zaprimljeni dokaz.
+     *
+     * <p>Identitet primaoca se čita iz {@code SecurityContextHolder} (principal = userId).
+     *
+     * @param unosId identifikator unosa u lancu nadzora
+     * @return 200 bez sadržaja ako je prihvatanje uspješno,
+     *         404 ako unos nije pronađen
+     */
     @PutMapping("/prihvati/{id}")
     @Operation(summary = "Prihvati zaprimljeni dokaz")
     @ApiResponses(value = {
@@ -64,6 +99,16 @@ public class LanacNadzoraController {
         return ResponseEntity.ok().build();
     }
 
+    /**
+     * PATCH /api/lanac-nadzora/{unosId}/potvrda - potvrđuje ili odbija primopredaju.
+     *
+     * <p>Identitet korisnika se čita iz {@code SecurityContextHolder} (principal = userId).
+     *
+     * @param unosId  identifikator unosa u lancu nadzora
+     * @param request tijelo zahtjeva sa statusom potvrde i opcionalnom napomenom
+     * @return 200 bez sadržaja ako je status ažuriran,
+     *         404 ako unos nije pronađen
+     */
     @PatchMapping("/{unosId}/potvrda")
     @Operation(summary = "Potvrdi ili odbij primopredaju")
     @ApiResponses(value = {

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/OsumnjiceniController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/OsumnjiceniController.java
@@ -16,6 +16,14 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * REST kontroler za upravljanje osumnjičenima.
+ *
+ * <p>Bazna putanja: {@code /api}. Pruža operacije za dohvat svih osumnjičenih,
+ * dohvat osumnjičenih po slučaju i dodavanje novog osumnjičenog na slučaj.
+ * Kreiranje osumnjičenog zahtijeva ulogu {@code SEF_STANICE} ili {@code INSPEKTOR}.
+ * Delegira sve operacije servisu {@code OsumnjiceniService}.
+ */
 @RestController
 @RequestMapping("/api")
 @Tag(name = "Osumnjičeni", description = "Upravljanje osumnjičenima")
@@ -23,10 +31,16 @@ public class OsumnjiceniController {
 
     private final OsumnjiceniService service;
 
+    /** Konstruktorska injekcija servisa za osumnjičene. */
     public OsumnjiceniController(OsumnjiceniService service) {
         this.service = service;
     }
 
+    /**
+     * GET /api/osumnjiceni - dohvata sve osumnjičene u sistemu.
+     *
+     * @return 200 + lista svih {@link Osumnjiceni}
+     */
     @GetMapping("/osumnjiceni")
     @Operation(summary = "Dohvati sve osumnjičene u sistemu")
     @ApiResponse(responseCode = "200", description = "Lista svih osumnjičenih vraćena")
@@ -35,6 +49,12 @@ public class OsumnjiceniController {
     }
 
 
+    /**
+     * GET /api/slucajevi/{caseId}/osumnjiceni - dohvata osumnjičene za određeni slučaj.
+     *
+     * @param caseId identifikator slučaja
+     * @return 200 + lista {@link OsumnjiceniDTO} za dati slučaj
+     */
     @GetMapping("/slucajevi/{caseId}/osumnjiceni")
     @Operation(summary = "Dohvati osumnjičene za konkretan slučaj")
     public ResponseEntity<List<OsumnjiceniDTO>> getByCaseId(@PathVariable Long caseId) {
@@ -42,6 +62,20 @@ public class OsumnjiceniController {
     }
 
 
+    /**
+     * POST /api/slucajevi/{caseId}/osumnjiceni - dodaje novog osumnjičenog na slučaj.
+     *
+     * <p>Samo {@code SEF_STANICE} i {@code INSPEKTOR} mogu dodavati osumnjičene
+     * ({@code @PreAuthorize("hasAnyRole('SEF_STANICE', 'INSPEKTOR')")}).
+     * Datum rođenja ne smije biti u budućnosti.
+     *
+     * @param caseId  identifikator slučaja
+     * @param request tijelo zahtjeva sa podacima novog osumnjičenog
+     * @return 201 + kreirani {@link Osumnjiceni},
+     *         400 ako je datum rođenja u budućnosti,
+     *         403 ako korisnik nema odgovarajuću ulogu,
+     *         500 pri grešci na serveru
+     */
     @PostMapping("/slucajevi/{caseId}/osumnjiceni")
     @PreAuthorize("hasAnyRole('SEF_STANICE', 'INSPEKTOR')")
     public ResponseEntity<?> create(

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/OsumnjiceniFotografijaController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/OsumnjiceniFotografijaController.java
@@ -12,6 +12,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * REST kontroler za upravljanje fotografijama osumnjičenih.
+ *
+ * <p>Bazna putanja: {@code /api/osumnjiceni}. Podržava dohvat, upload, ažuriranje
+ * i brisanje fotografija osumnjičenih. Upload i ažuriranje su multipart/form-data zahtjevi.
+ * Maksimalan broj fotografija po osumnjičenom je 3. Identitet korisnika se izvlači
+ * iz JWT tokena putem {@code JwtUtil.extractUserId}.
+ */
 @RestController
 @RequestMapping("/api/osumnjiceni")
 public class OsumnjiceniFotografijaController {
@@ -19,6 +27,7 @@ public class OsumnjiceniFotografijaController {
     private final OsumnjiceniFotografijaService osumnjiceniFotografijaService;
     private final JwtUtil jwtUtil;
 
+    /** Konstruktorska injekcija servisa za fotografije osumnjičenih i JWT pomoćnih metoda. */
     public OsumnjiceniFotografijaController(OsumnjiceniFotografijaService osumnjiceniFotografijaService,
                                             JwtUtil jwtUtil) {
         this.osumnjiceniFotografijaService = osumnjiceniFotografijaService;
@@ -26,8 +35,11 @@ public class OsumnjiceniFotografijaController {
     }
 
     /**
-     * GET /api/osumnjiceni/{osumnjiceniId}/fotografije
-     * Dobavljanje svih fotografija za osumnjičenog
+     * GET /api/osumnjiceni/{osumnjiceniId}/fotografije - dohvata sve fotografije za osumnjičenog.
+     *
+     * @param osumnjiceniId identifikator osumnjičenog
+     * @return 200 + lista {@link OsumnjiceniFotografijaDTO},
+     *         500 pri grešci na serveru
      */
     @GetMapping("/{osumnjiceniId}/fotografije")
     public ResponseEntity<List<OsumnjiceniFotografijaDTO>> getFotografije(@PathVariable Long osumnjiceniId) {
@@ -40,9 +52,20 @@ public class OsumnjiceniFotografijaController {
     }
 
     /**
-     * POST /api/osumnjiceni/{osumnjiceniId}/fotografije
-     * Upload fotografije za osumnjičenog
-     * Max 3 fotografije
+     * POST /api/osumnjiceni/{osumnjiceniId}/fotografije - upload fotografije za osumnjičenog.
+     *
+     * <p>Multipart/form-data zahtjev. Dozvoljeni formati: JPEG, PNG, GIF, WebP.
+     * Maksimalna veličina fajla: 5 MB. Maksimalan broj fotografija po osumnjičenom: 3.
+     * Identitet korisnika se izvlači iz JWT tokena putem {@code JwtUtil.extractUserId}.
+     *
+     * @param osumnjiceniId identifikator osumnjičenog
+     * @param file          fotografija kao multipart fajl
+     * @param redniBroj     opcionalni redni broj fotografije
+     * @param opis          opcionalni opis fotografije
+     * @param token         Authorization header u obliku {@code "Bearer <jwt>"}
+     * @return 201 + poruka o uspješnom uploadu,
+     *         400 ako je format, veličina ili broj fotografija neispravni,
+     *         500 pri grešci na serveru
      */
     @PostMapping("/{osumnjiceniId}/fotografije")
     public ResponseEntity<?> uploadFotografiju(@PathVariable Long osumnjiceniId,
@@ -93,8 +116,19 @@ public class OsumnjiceniFotografijaController {
     }
 
     /**
-     * PUT /api/osumnjiceni/{osumnjiceniId}/fotografije/{fotografijaId}
-     * Ažuriranje fotografije osumnjičenog
+     * PUT /api/osumnjiceni/{osumnjiceniId}/fotografije/{fotografijaId} - ažurira fotografiju osumnjičenog.
+     *
+     * <p>Multipart/form-data zahtjev. Identitet korisnika se izvlači iz JWT tokena
+     * putem {@code JwtUtil.extractUserId}.
+     *
+     * @param osumnjiceniId identifikator osumnjičenog
+     * @param fotografijaId identifikator fotografije koja se ažurira
+     * @param file          nova fotografija kao multipart fajl
+     * @param opis          opcionalni novi opis fotografije
+     * @param token         Authorization header u obliku {@code "Bearer <jwt>"}
+     * @return 200 + poruka o uspješnom ažuriranju,
+     *         400 pri neispravnom zahtjevu,
+     *         500 pri grešci na serveru
      */
     @PutMapping("/{osumnjiceniId}/fotografije/{fotografijaId}")
     public ResponseEntity<?> azurirajFotografiju(@PathVariable Long osumnjiceniId,
@@ -123,8 +157,14 @@ public class OsumnjiceniFotografijaController {
     }
 
     /**
-     * DELETE /api/osumnjiceni/{osumnjiceniId}/fotografije/{fotografijaId}
-     * Brisanje fotografije osumnjičenog
+     * DELETE /api/osumnjiceni/{osumnjiceniId}/fotografije/{fotografijaId} - briše fotografiju osumnjičenog.
+     *
+     * @param osumnjiceniId identifikator osumnjičenog
+     * @param fotografijaId identifikator fotografije koja se briše
+     * @param token         Authorization header u obliku {@code "Bearer <jwt>"}
+     * @return 200 + poruka o uspješnom brisanju,
+     *         400 pri neispravnom zahtjevu,
+     *         500 pri grešci na serveru
      */
     @DeleteMapping("/{osumnjiceniId}/fotografije/{fotografijaId}")
     public ResponseEntity<?> obrisiFotografiju(@PathVariable Long osumnjiceniId,

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/PrimopredajaController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/PrimopredajaController.java
@@ -16,16 +16,37 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * REST kontroler za upravljanje primopredajama dokaza.
+ *
+ * <p>Nema zajedničke bazne putanje — svaki handler definiše punu putanju.
+ * Pruža operacije za kreiranje primopredaje, pregled primopredaja koje čekaju potvrdu,
+ * pregled vlastitih slanja i poništavanje primopredaje. Identitet korisnika se čita
+ * iz {@code SecurityContextHolder} (principal = userId kao String).
+ * Delegira sve operacije servisu {@code LanacNadzoraService}.
+ */
 @RestController
 @Tag(name = "Primopredaje", description = "Primopredaja dokaza")
 public class PrimopredajaController {
 
     private final LanacNadzoraService lanacNadzoraService;
 
+    /** Konstruktorska injekcija servisa za lanac nadzora. */
     public PrimopredajaController(LanacNadzoraService lanacNadzoraService) {
         this.lanacNadzoraService = lanacNadzoraService;
     }
 
+    /**
+     * POST /api/dokazi/{dokazId}/primopredaja - kreira novu primopredaju dokaza.
+     *
+     * <p>Identitet inicijatora se čita iz {@code SecurityContextHolder} (principal = userId).
+     *
+     * @param dokazId identifikator dokaza koji se predaje
+     * @param request tijelo zahtjeva sa podacima primopredaje
+     * @return 200 + kreirani {@link LanacNadzora} unos,
+     *         400 ako je zahtjev neispravan,
+     *         500 pri grešci na serveru
+     */
     @PostMapping("/api/dokazi/{dokazId}/primopredaja")
     @Operation(summary = "Kreiraj primopredaju dokaza")
     @ApiResponses(value = {
@@ -41,6 +62,13 @@ public class PrimopredajaController {
         return ResponseEntity.ok(lanac);
     }
 
+    /**
+     * GET /api/primopredaje/ceka-potvrdu - dohvata primopredaje koje čekaju potvrdu prijavljenog korisnika.
+     *
+     * <p>Identitet korisnika se čita iz {@code SecurityContextHolder} (principal = userId).
+     *
+     * @return 200 + lista {@link PrimopredajaZaPotvrduDTO} koje čekaju potvrdu
+     */
     @GetMapping("/api/primopredaje/ceka-potvrdu")
     @Operation(summary = "Dohvati primopredaje koje čekaju potvrdu")
     @ApiResponse(responseCode = "200", description = "Lista primopredaja vraćena")
@@ -50,6 +78,13 @@ public class PrimopredajaController {
         return ResponseEntity.ok(lanacNadzoraService.getCekaPotvrduZaMene(userId));
     }
 
+    /**
+     * GET /api/primopredaje/moja-slanja - dohvata primopredaje koje je prijavljeni korisnik poslao na potvrdu.
+     *
+     * <p>Identitet korisnika se čita iz {@code SecurityContextHolder} (principal = userId).
+     *
+     * @return 200 + lista {@link MojaPrimopredajaDTO} vlastitih slanja
+     */
     @GetMapping("/api/primopredaje/moja-slanja")
     @Operation(summary = "Dohvati moja slanja na potvrdi")
     @ApiResponse(responseCode = "200", description = "Lista mojih slanja vraćena")
@@ -59,6 +94,16 @@ public class PrimopredajaController {
         return ResponseEntity.ok(lanacNadzoraService.getMojaSlanjaNaPotvrdi(userId));
     }
 
+    /**
+     * DELETE /api/primopredaje/{unosId}/ponisti - poništava primopredaju.
+     *
+     * <p>Identitet korisnika se čita iz {@code SecurityContextHolder} (principal = userId).
+     *
+     * @param unosId  identifikator unosa u lancu nadzora koji se poništava
+     * @param request tijelo zahtjeva sa razlogom poništavanja
+     * @return 200 bez sadržaja ako je poništavanje uspješno,
+     *         404 ako unos nije pronađen
+     */
     @DeleteMapping("/api/primopredaje/{unosId}/ponisti")
     @Operation(summary = "Poništi primopredaju")
     @ApiResponses(value = {

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/SlucajController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/SlucajController.java
@@ -21,6 +21,17 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * REST kontroler za upravljanje krivičnim slučajevima.
+ *
+ * <p>Bazna putanja: {@code /api/slucajevi}. Pruža operacije za dohvat, kreiranje,
+ * ažuriranje statusa slučajeva, upravljanje svjedocima i generisanje PDF izvještaja.
+ * Kreiranje slučaja zahtijeva ulogu {@code SEF_STANICE} ili {@code INSPEKTOR}.
+ * Identitet korisnika se čita iz {@code SecurityContextHolder}; stanicaId se
+ * izvlači iz JWT tokena putem {@code JwtUtil.extractStanicaId} kada nije proslijeđen
+ * u tijelu zahtjeva. Delegira operacije servisima {@code SlucajService},
+ * {@code SvjedokService} i {@code OsumnjiceniService}.
+ */
 @RestController
 @RequestMapping("/api/slucajevi")
 @Tag(name = "Slučajevi", description = "Upravljanje slučajevima")
@@ -31,6 +42,7 @@ public class SlucajController {
     private final OsumnjiceniService osumnjiceniService;
     private final JwtUtil jwtUtil;
 
+    /** Konstruktorska injekcija servisa za slučajeve, svjedoke, osumnjičene i JWT pomoćnih metoda. */
     public SlucajController(SlucajService slucajService,
                             SvjedokService svjedokService,
                             OsumnjiceniService osumnjiceniService,
@@ -41,6 +53,13 @@ public class SlucajController {
         this.jwtUtil = jwtUtil;
     }
 
+    /**
+     * GET /api/slucajevi/broj/{brojSlucaja} - dohvata detalje slučaja po broju slučaja.
+     *
+     * @param brojSlucaja broj slučaja (alfanumerički identifikator)
+     * @return 200 + {@link SlucajDetaljiDTO} sa svim detaljima slučaja,
+     *         404 ako slučaj nije pronađen
+     */
     @GetMapping("/broj/{brojSlucaja}")
     @Operation(summary = "Dohvati detalje slučaja po broju")
     @ApiResponses(value = {
@@ -57,6 +76,14 @@ public class SlucajController {
         return ResponseEntity.ok(detalji);
     }
 
+    /**
+     * GET /api/slucajevi - dohvata sve slučajeve filtrirane prema ulozi prijavljenog korisnika.
+     *
+     * <p>Identitet i uloga korisnika se čitaju iz {@code SecurityContextHolder}.
+     * Filtriranje po ulozi vrši {@code SlucajService.getSlucajeviFiltered}.
+     *
+     * @return 200 + lista {@link SlucajListDTO} filtrirana prema ulozi korisnika
+     */
     @GetMapping
     @Operation(summary = "Dohvati sve slučajeve (filtriran po roli)")
     @ApiResponse(responseCode = "200", description = "Lista slučajeva vraćena")
@@ -74,6 +101,13 @@ public class SlucajController {
         return ResponseEntity.ok(slucajevi);
     }
 
+    /**
+     * GET /api/slucajevi/{id} - dohvata slučaj po internom ID-u.
+     *
+     * @param id interni identifikator slučaja
+     * @return 200 + {@link SlucajListDTO},
+     *         404 ako slučaj nije pronađen
+     */
     @GetMapping("/{id}")
     @Operation(summary = "Dohvati slučaj po ID-u")
     @ApiResponses(value = {
@@ -86,6 +120,15 @@ public class SlucajController {
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
+    /**
+     * PATCH /api/slucajevi/{id}/status - ažurira status slučaja.
+     *
+     * @param id      interni identifikator slučaja
+     * @param request tijelo zahtjeva sa novim statusom
+     * @return 200 ako je status uspješno ažuriran,
+     *         400 ako je status nevalidan,
+     *         404 ako slučaj nije pronađen
+     */
     @PatchMapping("/{id}/status")
     @Operation(summary = "Ažuriraj status slučaja")
     @ApiResponses(value = {
@@ -105,6 +148,13 @@ public class SlucajController {
         }
     }
 
+    /**
+     * GET /api/slucajevi/{id}/izvjestaj - dohvata izvještaj za slučaj.
+     *
+     * @param id interni identifikator slučaja
+     * @return 200 + {@link IzvjestajDTO},
+     *         404 ako izvještaj nije pronađen
+     */
     @GetMapping("/{id}/izvjestaj")
     @Operation(summary = "Dohvati izvještaj za slučaj")
     @ApiResponses(value = {
@@ -117,6 +167,21 @@ public class SlucajController {
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
+    /**
+     * POST /api/slucajevi - kreira novi krivični slučaj.
+     *
+     * <p>Samo {@code SEF_STANICE} i {@code INSPEKTOR} mogu kreirati slučajeve
+     * ({@code @PreAuthorize("hasAnyRole('SEF_STANICE', 'INSPEKTOR')")}).
+     * Identitet korisnika se čita iz {@code SecurityContextHolder}. Ako {@code stanicaId}
+     * nije proslijeđen u tijelu zahtjeva, izvlači se iz JWT tokena putem
+     * {@code JwtUtil.extractStanicaId}.
+     *
+     * @param request     tijelo zahtjeva sa podacima novog slučaja
+     * @param httpRequest HTTP zahtjev iz kojeg se izvlači JWT token za stanicaId
+     * @return 201 + kreirani {@link SlucajListDTO},
+     *         403 ako korisnik nema odgovarajuću ulogu,
+     *         500 pri grešci na serveru
+     */
     @PreAuthorize("hasAnyRole('SEF_STANICE', 'INSPEKTOR')")
     @PostMapping
     @Operation(summary = "Kreiraj novi slučaj")
@@ -146,6 +211,14 @@ public class SlucajController {
         }
     }
 
+    /**
+     * GET /api/slucajevi/moji - dohvata slučajeve prijavljenog korisnika.
+     *
+     * <p>Identitet i uloga korisnika se čitaju iz {@code SecurityContextHolder}.
+     * Filtriranje po ulozi vrši {@code SlucajService.getMojiSlucajevi}.
+     *
+     * @return 200 + lista {@link MojSlucajDTO} slučajeva vezanih za prijavljenog korisnika
+     */
     @GetMapping("/moji")
     @Operation(summary = "Dohvati moje slučajeve")
     @ApiResponse(responseCode = "200", description = "Lista mojih slučajeva vraćena")
@@ -163,6 +236,14 @@ public class SlucajController {
         return ResponseEntity.ok(slucajevi);
     }
 
+    /**
+     * POST /api/slucajevi/{slucajId}/svjedoci - dodaje svjedoka na slučaj.
+     *
+     * @param slucajId identifikator slučaja
+     * @param request  tijelo zahtjeva sa podacima svjedoka
+     * @return 201 + {@link SvjedokDTO} kreiranog svjedoka,
+     *         500 pri grešci na serveru
+     */
     @PostMapping("/{slucajId}/svjedoci")
     @Operation(summary = "Dodaj svjedoka na slučaj")
     @ApiResponses(value = {
@@ -205,6 +286,18 @@ public class SlucajController {
         }
     }*/
 
+    /**
+     * GET /api/slucajevi/{id}/generate-report - generiše i preuzima PDF izvještaj za slučaj.
+     *
+     * <p>Vraća binarni PDF fajl kao {@code application/pdf} sa {@code Content-Disposition: attachment}.
+     * Identitet korisnika se izvlači iz JWT tokena putem {@code JwtUtil.extractUserId}.
+     *
+     * @param id      interni identifikator slučaja
+     * @param request HTTP zahtjev iz kojeg se izvlači JWT token
+     * @return 200 + PDF bajt-niz sa odgovarajućim headerima za preuzimanje,
+     *         404 ako slučaj nije pronađen,
+     *         500 pri grešci pri generisanju PDF-a
+     */
     @GetMapping("/{id}/generate-report")
     @Operation(summary = "Generiši i preuzmi PDF izvještaj za slučaj")
     @ApiResponses(value = {

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/SlucajKrivicnoDjeloController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/SlucajKrivicnoDjeloController.java
@@ -12,16 +12,30 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * REST kontroler za upravljanje krivičnim djelima na konkretnom slučaju.
+ *
+ * <p>Bazna putanja: {@code /api/slucajevi/{slucajId}/krivicna-djela}. Pruža operacije
+ * za dohvat, dodavanje (pojedinačno i grupno) i uklanjanje krivičnih djela sa slučaja.
+ * Delegira sve operacije servisu {@code SlucajKrivicnoDjeloService}.
+ */
 @RestController
 @RequestMapping("/api/slucajevi/{slucajId}/krivicna-djela")
 @Tag(name = "Krivična djela na slučaju", description = "Upravljanje krivičnim djelima na konkretnom slučaju")
 public class SlucajKrivicnoDjeloController {
     private final SlucajKrivicnoDjeloService service;
 
+    /** Konstruktorska injekcija servisa za krivična djela na slučaju. */
     public SlucajKrivicnoDjeloController(SlucajKrivicnoDjeloService service) {
         this.service = service;
     }
 
+    /**
+     * GET /api/slucajevi/{slucajId}/krivicna-djela - dohvata sva krivična djela za slučaj.
+     *
+     * @param slucajId identifikator slučaja
+     * @return 200 + lista {@link SlucajKrivicnoDjelo} za dati slučaj
+     */
     @GetMapping
     @Operation(summary = "Dohvati sva krivična djela za slučaj")
     @ApiResponse(responseCode = "200", description = "Lista krivičnih djela vraćena")
@@ -29,6 +43,15 @@ public class SlucajKrivicnoDjeloController {
         return ResponseEntity.ok(service.getDjelaZaSlucaj(slucajId));
     }
 
+    /**
+     * POST /api/slucajevi/{slucajId}/krivicna-djela - dodaje jedno krivično djelo na slučaj.
+     *
+     * @param slucajId identifikator slučaja
+     * @param body     mapa sa ključem {@code djeloId} koji sadrži ID krivičnog djela
+     * @return 201 + kreirani {@link SlucajKrivicnoDjelo},
+     *         400 ako su podaci nevalidni,
+     *         409 ako veza već postoji
+     */
     @PostMapping
     @Operation(summary = "Dodaj krivično djelo na slučaj")
     @ApiResponses(value = {
@@ -43,6 +66,14 @@ public class SlucajKrivicnoDjeloController {
         return ResponseEntity.status(201).body(service.dodajDjeloNaSlucaj(slucajId, djeloId));
     }
 
+    /**
+     * POST /api/slucajevi/{slucajId}/krivicna-djela/batch - dodaje više krivičnih djela na slučaj odjednom.
+     *
+     * @param slucajId identifikator slučaja
+     * @param body     mapa sa ključem {@code djeloIds} koji sadrži listu ID-ova krivičnih djela
+     * @return 201 bez sadržaja ako su sva krivična djela uspješno dodana,
+     *         400 ako su podaci nevalidni
+     */
     @PostMapping("/batch")
     @Operation(summary = "Dodaj više krivičnih djela na slučaj odjednom")
     @ApiResponses(value = {
@@ -57,6 +88,14 @@ public class SlucajKrivicnoDjeloController {
         return ResponseEntity.status(201).build();
     }
 
+    /**
+     * DELETE /api/slucajevi/{slucajId}/krivicna-djela/{vezaId} - uklanja krivično djelo sa slučaja.
+     *
+     * @param slucajId identifikator slučaja
+     * @param vezaId   identifikator veze između slučaja i krivičnog djela
+     * @return 204 bez sadržaja,
+     *         404 ako veza nije pronađena
+     */
     @DeleteMapping("/{vezaId}")
     @Operation(summary = "Ukloni krivično djelo sa slučaja")
     @ApiResponses(value = {

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/StanicaController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/StanicaController.java
@@ -12,16 +12,32 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * REST kontroler za upravljanje policijskim stanicama.
+ *
+ * <p>Izlaže resurse na putanji {@code /api/stanice} i delegira poslovnu logiku
+ * servisu {@link StanicaService}.</p>
+ */
 @RestController
 @RequestMapping("/api/stanice")
 @Tag(name = "Stanice", description = "Policijske stanice")
 public class StanicaController {
     private final StanicaService service;
 
+    /**
+     * Kreira instancu kontrolera s injektovanim servisom za stanice.
+     *
+     * @param service servis za upravljanje policijskim stanicama
+     */
     public StanicaController(StanicaService service) {
         this.service = service;
     }
 
+    /**
+     * {@code GET /api/stanice} — vraća listu svih policijskih stanica.
+     *
+     * @return HTTP 200 s listom svih stanica
+     */
     @GetMapping
     @Operation(summary = "Dohvati sve policijske stanice")
     @ApiResponse(responseCode = "200", description = "Lista stanica vraćena")
@@ -29,6 +45,12 @@ public class StanicaController {
         return ResponseEntity.ok(service.getAll());
     }
 
+    /**
+     * {@code GET /api/stanice/{id}} — vraća policijsku stanicu s traženim ID-om.
+     *
+     * @param id jedinstveni identifikator stanice
+     * @return HTTP 200 s podacima stanice, ili HTTP 404 ako stanica nije pronađena
+     */
     @GetMapping("/{id}")
     @Operation(summary = "Dohvati policijsku stanicu po ID-u")
     @ApiResponses(value = {
@@ -39,6 +61,13 @@ public class StanicaController {
         return ResponseEntity.ok(service.getById(id));
     }
 
+    /**
+     * {@code POST /api/stanice/register} — registruje novu policijsku stanicu zajedno
+     * s njenim šefom. Endpoint je javan i ne zahtijeva autentifikaciju.
+     *
+     * @param request podaci za registraciju stanice i šefa stanice
+     * @return HTTP 201 s porukom uspjeha, ili HTTP 400 u slučaju greške pri registraciji
+     */
     @PostMapping("/register")
     @Operation(summary = "Registruj novu policijsku stanicu")
     @ApiResponses(value = {

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/SvjedokController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/SvjedokController.java
@@ -11,15 +11,33 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * REST kontroler za upravljanje svjedocima vezanim za krivične slučajeve.
+ *
+ * <p>Nema klasnu anotaciju {@code @RequestMapping} — svaki handler definiše
+ * punu putanju. Delegira poslovnu logiku servisu {@link SvjedokService}.</p>
+ */
 @RestController
 @Tag(name = "Svjedoci", description = "Upravljanje svjedocima")
 public class SvjedokController {
     private final SvjedokService service;
 
+    /**
+     * Kreira instancu kontrolera s injektovanim servisom za svjedoke.
+     *
+     * @param service servis za upravljanje svjedocima
+     */
     public SvjedokController(SvjedokService service) {
         this.service = service;
     }
 
+    /**
+     * {@code GET /api/slucajevi/{caseId}/svjedoci} — vraća listu svjedoka
+     * za zadani krivični slučaj.
+     *
+     * @param caseId jedinstveni identifikator krivičnog slučaja
+     * @return HTTP 200 s listom svjedoka, ili HTTP 404 ako slučaj nije pronađen
+     */
     @GetMapping("/api/slucajevi/{caseId}/svjedoci")
     @Operation(summary = "Dohvati svjedoke za slučaj")
     @ApiResponses(value = {

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/TimController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/TimController.java
@@ -13,16 +13,34 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * REST kontroler za upravljanje timovima na krivičnim slučajevima.
+ *
+ * <p>Nema klasnu anotaciju {@code @RequestMapping} — svaki handler definiše
+ * punu putanju. Delegira poslovnu logiku servisu {@link TimService}.</p>
+ */
 @RestController
 @Tag(name = "Tim", description = "Upravljanje timom na slučaju")
 public class TimController {
 
     private final TimService timService;
 
+    /**
+     * Kreira instancu kontrolera s injektovanim servisom za timove.
+     *
+     * @param timService servis za upravljanje timovima na slučajevima
+     */
     public TimController(TimService timService) {
         this.timService = timService;
     }
 
+    /**
+     * {@code GET /api/slucajevi/{caseId}/tim} — vraća listu članova tima
+     * dodijeljenih zadanom krivičnom slučaju.
+     *
+     * @param caseId jedinstveni identifikator krivičnog slučaja
+     * @return HTTP 200 s listom članova tima
+     */
     @GetMapping("/api/slucajevi/{caseId}/tim")
     @Operation(summary = "Dohvati članove tima na slučaju")
     @ApiResponse(responseCode = "200", description = "Lista članova tima vraćena")
@@ -30,6 +48,14 @@ public class TimController {
         return ResponseEntity.ok(timService.getClanoviTima(caseId));
     }
 
+    /**
+     * {@code POST /api/slucajevi/{caseId}/tim} — dodaje novog člana tima
+     * na zadani krivični slučaj.
+     *
+     * @param caseId  jedinstveni identifikator krivičnog slučaja
+     * @param request podaci o uposleniku koji se dodaje u tim
+     * @return HTTP 201 s podacima novokreirane dodjele, ili HTTP 400/500 u slučaju greške
+     */
     @PostMapping("/api/slucajevi/{caseId}/tim")
     @Operation(summary = "Dodaj člana tima na slučaj")
     @ApiResponses(value = {
@@ -43,6 +69,13 @@ public class TimController {
         return ResponseEntity.status(HttpStatus.CREATED).body(timClanDTO);
     }
 
+    /**
+     * {@code DELETE /api/tim/{dodjelaId}/ukloni} — uklanja člana tima
+     * prema ID-u dodjele.
+     *
+     * @param dodjelaId jedinstveni identifikator dodjele člana tima
+     * @return HTTP 200 bez tijela, ili HTTP 404 ako dodjela nije pronađena
+     */
     @DeleteMapping("/api/tim/{dodjelaId}/ukloni")
     @Operation(summary = "Ukloni člana tima")
     @ApiResponses(value = {

--- a/suds/src/main/java/ba/unsa/etf/suds/controller/UposlenikController.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/controller/UposlenikController.java
@@ -16,6 +16,14 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * REST kontroler za upravljanje uposlenicima policijske stanice.
+ *
+ * <p>Izlaže resurse na putanji {@code /api/uposlenici} i delegira poslovnu logiku
+ * servisu {@link UposlenikService}. Većina handlera ekstrahuje {@code stanicaId}
+ * iz JWT tokena putem {@link JwtUtil#extractStanicaId(String)} kako bi operacije
+ * bile ograničene na stanicu trenutno prijavljenog korisnika.</p>
+ */
 @RestController
 @RequestMapping("/api/uposlenici")
 @Tag(name = "Uposlenici", description = "Upravljanje uposlenicima")
@@ -24,11 +32,27 @@ public class UposlenikController {
     private final UposlenikService uposlenikService;
     private final JwtUtil jwtUtil;
 
+    /**
+     * Kreira instancu kontrolera s injektovanim servisom i JWT pomoćnom klasom.
+     *
+     * @param uposlenikService servis za upravljanje uposlenicima
+     * @param jwtUtil          pomoćna klasa za ekstrakciju podataka iz JWT tokena
+     */
     public UposlenikController(UposlenikService uposlenikService, JwtUtil jwtUtil) {
         this.uposlenikService = uposlenikService;
         this.jwtUtil = jwtUtil;
     }
 
+    /**
+     * {@code GET /api/uposlenici} — vraća listu svih uposlenika stanice
+     * trenutno prijavljenog korisnika.
+     *
+     * <p>Identifikator stanice ekstrahuje se iz JWT tokena pozivom
+     * {@link JwtUtil#extractStanicaId(String)}.</p>
+     *
+     * @param httpRequest HTTP zahtjev iz kojeg se čita {@code Authorization} zaglavlje
+     * @return HTTP 200 s listom uposlenika, ili HTTP 500 u slučaju greške
+     */
     @GetMapping
     @Operation(summary = "Dohvati sve uposlenike stanice")
     @ApiResponses(value = {
@@ -48,6 +72,12 @@ public class UposlenikController {
         }
     }
 
+    /**
+     * {@code GET /api/uposlenici/{id}} — vraća podatke uposlenika s traženim ID-om.
+     *
+     * @param id jedinstveni identifikator uposlenika
+     * @return HTTP 200 s podacima uposlenika, ili HTTP 404 ako uposlenik nije pronađen
+     */
     @GetMapping("/{id}")
     @Operation(summary = "Dohvati uposlenika po ID-u")
     @ApiResponses(value = {
@@ -58,6 +88,20 @@ public class UposlenikController {
         return ResponseEntity.ok(uposlenikService.getUposlenikById(id));
     }
 
+    /**
+     * {@code PUT /api/uposlenici/{id}} — ažurira lične i profesionalne podatke
+     * uposlenika s traženim ID-om.
+     *
+     * <p>Identifikator stanice ekstrahuje se iz JWT tokena pozivom
+     * {@link JwtUtil#extractStanicaId(String)} kako bi se spriječilo
+     * mijenjanje uposlenika iz druge stanice.</p>
+     *
+     * @param id          jedinstveni identifikator uposlenika
+     * @param request     novi podaci uposlenika
+     * @param httpRequest HTTP zahtjev iz kojeg se čita {@code Authorization} zaglavlje
+     * @return HTTP 200 s porukom uspjeha, HTTP 403 ako uposlenik nije u istoj stanici,
+     *         ili HTTP 400 u slučaju druge greške
+     */
     @PutMapping("/{id}")
     @Operation(summary = "Ažuriraj podatke uposlenika")
     @ApiResponses(value = {
@@ -82,6 +126,19 @@ public class UposlenikController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Greška: " + e.getMessage());
         }
     }
+    /**
+     * {@code PUT /api/uposlenici/{id}/password-reset} — resetuje lozinku uposlenika
+     * s traženim ID-om.
+     *
+     * <p>Identifikator stanice ekstrahuje se iz JWT tokena pozivom
+     * {@link JwtUtil#extractStanicaId(String)} kako bi se osiguralo da se
+     * resetuje lozinka uposlenika iz iste stanice.</p>
+     *
+     * @param id          jedinstveni identifikator uposlenika
+     * @param request     mapa s ključem {@code novaLozinka} koji sadrži novu lozinku
+     * @param httpRequest HTTP zahtjev iz kojeg se čita {@code Authorization} zaglavlje
+     * @return HTTP 200 s porukom uspjeha, ili HTTP 404 ako uposlenik nije pronađen
+     */
     @PutMapping("/{id}/password-reset")
     @Operation(summary = "Resetuj lozinku uposlenika")
     @ApiResponses(value = {
@@ -95,6 +152,18 @@ public ResponseEntity<?> resetLozinke(@PathVariable Long id, @RequestBody java.u
     return ResponseEntity.ok("Lozinka uspješno resetovana.");
 }
 
+    /**
+     * {@code POST /api/uposlenici} — dodaje novog uposlenika u stanicu
+     * trenutno prijavljenog korisnika.
+     *
+     * <p>Identifikator stanice ekstrahuje se iz JWT tokena pozivom
+     * {@link JwtUtil#extractStanicaId(String)}.</p>
+     *
+     * @param request     podaci novog uposlenika
+     * @param httpRequest HTTP zahtjev iz kojeg se čita {@code Authorization} zaglavlje
+     * @return HTTP 201 s porukom uspjeha, HTTP 400 u slučaju poslovne greške,
+     *         ili HTTP 500 u slučaju neočekivane greške
+     */
    @PostMapping
     @Operation(summary = "Dodaj novog uposlenika")
     @ApiResponses(value = {
@@ -120,6 +189,20 @@ public ResponseEntity<?> resetLozinke(@PathVariable Long id, @RequestBody java.u
         }
     }
 
+    /**
+     * {@code PUT /api/uposlenici/{id}/status} — mijenja status uposlenika
+     * (npr. aktivan/neaktivan).
+     *
+     * <p>Identifikator stanice i ID trenutnog korisnika ekstrahuju se iz JWT tokena
+     * pozivima {@link JwtUtil#extractStanicaId(String)} i
+     * {@link JwtUtil#extractUserId(String)}.</p>
+     *
+     * @param id          jedinstveni identifikator uposlenika čiji se status mijenja
+     * @param request     novi status uposlenika
+     * @param httpRequest HTTP zahtjev iz kojeg se čita {@code Authorization} zaglavlje
+     * @return HTTP 200 s porukom uspjeha, HTTP 403 ako je pristup zabranjen,
+     *         HTTP 400 u slučaju poslovne greške, ili HTTP 500 u slučaju neočekivane greške
+     */
     @PutMapping("/{id}/status")
     @Operation(summary = "Promijeni status uposlenika")
     @ApiResponses(value = {
@@ -153,6 +236,13 @@ public ResponseEntity<?> resetLozinke(@PathVariable Long id, @RequestBody java.u
         }
     }
 
+    /**
+     * Ekstrahuje JWT token iz {@code Authorization: Bearer <token>} zaglavlja zahtjeva.
+     *
+     * @param request HTTP zahtjev
+     * @return JWT token bez prefiksa {@code Bearer }
+     * @throws RuntimeException ako zaglavlje nije prisutno ili nema ispravan format
+     */
     private String extractToken(HttpServletRequest request) {
         String authHeader = request.getHeader("Authorization");
         if (authHeader != null && authHeader.startsWith("Bearer ")) {

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/DodajClanaTRequest.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/DodajClanaTRequest.java
@@ -4,9 +4,18 @@ import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
+/**
+ * Tijelo zahtjeva za POST /api/slucajevi/{id}/tim.
+ *
+ * <p>Dodaje postojećeg uposlenika u tim slučaja s određenom ulogom.
+ * JSON polja su u snake_case formatu.
+ */
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class DodajClanaTRequest {
+    /** ID uposlenika (NBP_USER) koji se dodaje u tim. */
     private Long uposlenikId;
+
+    /** Uloga uposlenika na ovom slučaju (npr. "VODITELJ", "ISTRAŽITELJ"). */
     private String ulogaNaSlucaju;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/DodajOsumnjicenogRequest.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/DodajOsumnjicenogRequest.java
@@ -4,15 +4,33 @@ import lombok.Data;
 
 import java.sql.Date;
 
+/**
+ * Tijelo zahtjeva za POST /api/slucajevi/{id}/osumnjiceni.
+ *
+ * <p>Kreira novog osumnjičenog i vezuje ga za slučaj. Adresa se
+ * proslijeđuje kao slobodna polja koja se upisuju u tabelu ADRESE.
+ */
 @Data
 public class DodajOsumnjicenogRequest {
+    /** Puno ime i prezime osumnjičenog. */
     private String imePrezime;
+
+    /** Jedinstveni matični broj građana osumnjičenog. */
     private String jmbg;
+
+    /** Datum rođenja osumnjičenog. */
     @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
     private Date datumRodjenja;
 
+    /** Ulica i kućni broj adrese stanovanja osumnjičenog. */
     private String ulicaIBroj;
+
+    /** Grad adrese stanovanja osumnjičenog. */
     private String grad;
+
+    /** Poštanski broj adrese stanovanja osumnjičenog. */
     private String postanskiBroj;
+
+    /** Država adrese stanovanja osumnjičenog. */
     private String drzava;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/DodajSvjedokaRequest.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/DodajSvjedokaRequest.java
@@ -4,19 +4,40 @@ import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
+/**
+ * Tijelo zahtjeva za POST /api/slucajevi/{id}/svjedoci (dodavanje postojećeg svjedoka).
+ *
+ * <p>Adresa se može proslijediti kao jednopoljna vrijednost ({@code adresa})
+ * ili kao strukturirana polja (ulicaIBroj, grad, postanskiBroj, drzava).
+ * JSON polja su u snake_case formatu.
+ */
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class DodajSvjedokaRequest {
+    /** Puno ime i prezime svjedoka. */
     private String imePrezime;
+
+    /** Jedinstveni matični broj građana svjedoka. */
     private String jmbg;
+
+    /** Kontakt telefon svjedoka. */
     private String kontaktTelefon;
+
+    /** Dodatne bilješke o svjedoku ili iskazu. */
     private String biljeska;
 
     /** Jednopoljna adresa iz frontenda (koristi se ako ulicaIBroj nije postavljen) */
     private String adresa;
 
+    /** Ulica i kućni broj adrese stanovanja svjedoka. */
     private String ulicaIBroj;
+
+    /** Grad adrese stanovanja svjedoka. */
     private String grad;
+
+    /** Poštanski broj adrese stanovanja svjedoka. */
     private String postanskiBroj;
+
+    /** Država adrese stanovanja svjedoka. */
     private String drzava;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/DodajUposlenikaRequest.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/DodajUposlenikaRequest.java
@@ -3,16 +3,41 @@ package ba.unsa.etf.suds.dto;
 import lombok.Data;
 import java.time.LocalDate;
 
+/**
+ * Tijelo zahtjeva za POST /api/uposlenici.
+ *
+ * <p>Šef stanice koristi ovaj zahtjev za kreiranje novog uposlenika
+ * unutar svoje stanice. Lozinka se hashira BCrypt-om na serveru.
+ */
 @Data
 public class DodajUposlenikaRequest {
+    /** Ime uposlenika. */
     private String firstName;
+
+    /** Prezime uposlenika. */
     private String lastName;
+
+    /** Email adresa uposlenika (koristi se i za prijavu). */
     private String email;
+
+    /** Korisničko ime uposlenika. */
     private String username;
+
+    /** Lozinka u plain-text obliku (BCrypt hashiranje radi server). */
     private String password;
+
+    /** Kontakt telefon uposlenika. */
     private String phoneNumber;
+
+    /** Datum rođenja uposlenika. */
     private LocalDate birthDate;
+
+    /** ID adrese iz tabele ADRESE. */
     private Long addressId;
+
+    /** ID uloge iz tabele NBP_ROLE. */
     private Long roleId;
+
+    /** Broj značke uposlenika — jedinstven unutar stanice. */
     private String brojZnacke;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/DokazDosijeDTO.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/DokazDosijeDTO.java
@@ -5,9 +5,20 @@ import ba.unsa.etf.suds.model.LanacNadzora;
 import lombok.Data;
 import java.util.List;
 
+/**
+ * Odgovor za GET /api/dokazi/{id}/dosije.
+ *
+ * <p>Kompletni dosije dokaza koji uključuje osnovne podatke o dokazu,
+ * cijeli lanac nadzora (primopredaje) i forenzički zaključak ako postoji.
+ */
 @Data
 public class DokazDosijeDTO {
+    /** Osnovni podaci o dokazu iz tabele DOKAZI. */
     private Dokaz dokaz;
+
+    /** Hronološki niz svih primopredaja dokaza (lanac nadzora). */
     private List<LanacNadzora> lanacNadzora;
+
+    /** Forenzički zaključak iz izvještaja vezanog za ovaj dokaz. */
     private String forenzickiZakljucak;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/DokazFotografijaDTO.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/DokazFotografijaDTO.java
@@ -5,19 +5,43 @@ import lombok.Setter;
 
 import java.sql.Timestamp;
 
+/**
+ * Odgovor za GET /api/dokazi/{id}/fotografije.
+ *
+ * <p>Predstavlja jednu fotografiju dokaza s Base64-enkodiranim sadržajem
+ * pogodnim za direktno prikazivanje u SPA-u bez dodatnih zahtjeva.
+ */
 @Setter
 @Getter
 public class DokazFotografijaDTO {
-    // Getteri i setteri
+    /** Primarni ključ fotografije iz tabele FOTOGRAFIJE_DOKAZA. */
     private Long fotografijaId;
+
+    /** ID dokaza kojemu fotografija pripada. */
     private Long dokazId;
-    private String fotografijaBase64; // Base64 enkodirana slika za frontend
+
+    /** Base64-enkodirana slika za direktno prikazivanje u frontendu. */
+    private String fotografijaBase64;
+
+    /** Originalni naziv fajla fotografije. */
     private String nazivFajla;
+
+    /** MIME tip fotografije (npr. "image/jpeg"). */
     private String mimeType;
+
+    /** Veličina fajla u bajtovima. */
     private Long velicinaFajla;
+
+    /** Redni broj fotografije unutar skupa fotografija dokaza. */
     private Integer redniBroj;
+
+    /** Datum i vrijeme dodavanja fotografije. */
     private Timestamp datumDodavanja;
+
+    /** Ime i prezime uposlenika koji je dodao fotografiju. */
     private String dodaoIme;
+
+    /** Tekstualni opis sadržaja fotografije. */
     private String opisFotografije;
 
     // Konstruktori

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/DokazListDTO.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/DokazListDTO.java
@@ -6,15 +6,36 @@ import lombok.Data;
 
 import java.sql.Timestamp;
 
+/**
+ * Odgovor za GET /api/slucajevi/{id}/dokazi i GET /api/dokazi.
+ *
+ * <p>Sažeti prikaz jednog dokaza namijenjen listama u SPA-u.
+ * JSON polja su u snake_case formatu.
+ */
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class DokazListDTO {
+    /** Primarni ključ dokaza iz tabele DOKAZI. */
     private Long dokazId;
+
+    /** Tekstualni opis dokaza. */
     private String opis;
+
+    /** Lokacija na kojoj je dokaz pronađen. */
     private String lokacijaPronalaska;
+
+    /** Tip dokaza (npr. "FIZIČKI", "DIGITALNI"). */
     private String tipDokaza;
+
+    /** Trenutni status dokaza u lancu nadzora. */
     private String status;
+
+    /** Ime i prezime uposlenika koji je prikupio dokaz. */
     private String prikupioIme;
+
+    /** Datum i vrijeme prikupljanja dokaza. */
     private Timestamp datumPrikupa;
+
+    /** ID slučaja kojemu dokaz pripada. */
     private Long slucajId;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/DokazStanjeDTO.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/DokazStanjeDTO.java
@@ -6,18 +6,37 @@ import lombok.Data;
 
 import java.sql.Timestamp;
 
+/**
+ * Odgovor za GET /api/dokazi/{id}/stanje.
+ *
+ * <p>Prikazuje trenutno stanje dokaza u lancu nadzora: ko ga drži i
+ * može li ga predati. JSON polja su u snake_case formatu.
+ */
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class DokazStanjeDTO {
+    /** Indikator može li trenutni nosilac predati dokaz drugom uposleniku. */
     private boolean mozePredati;
+
+    /** Informacije o trenutnom nosiocu dokaza. */
     private TrenutniNosilacInfo trenutniNosilac;
 
+    /**
+     * Detalji o uposleniku koji trenutno drži dokaz.
+     */
     @Data
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class TrenutniNosilacInfo {
+        /** ID uposlenika koji trenutno drži dokaz. */
         private Long trenutniNosilacId;
+
+        /** Ime i prezime uposlenika koji trenutno drži dokaz. */
         private String trenutniNosilacIme;
+
+        /** Status posljednje primopredaje (npr. "POTVRĐENO", "NA_ČEKANJU"). */
         private String status;
+
+        /** Datum i vrijeme posljednje primopredaje. */
         private Timestamp zadnjaPrimopredaja;
     }
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/IzvjestajDTO.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/IzvjestajDTO.java
@@ -4,15 +4,38 @@ import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
 
+/**
+ * Odgovor za GET /api/slucajevi/{id}/izvjestaj.
+ *
+ * <p>Kompletan izvještaj slučaja koji agregira sve relevantne podatke:
+ * detalje slučaja, dokaze s fotografijama, lanac nadzora, tim, svjedoke,
+ * osumnjičene, krivična djela i forenzičke izvještaje. Koristi se za
+ * generisanje PDF izvještaja putem iText 7.
+ */
 public class IzvjestajDTO {
 
+    /** Osnovni podaci o slučaju. */
     private SlucajInfo slucaj;
+
+    /** Lista dokaza vezanih za slučaj. */
     private List<DokazInfo> dokazi;
+
+    /** Hronološki niz svih primopredaja dokaza u slučaju. */
     private List<LanacNadzoraInfo> lanacNadzora;
+
+    /** Članovi tima dodjeljeni slučaju. */
     private List<TimInfo> tim;
+
+    /** Svjedoci vezani za slučaj. */
     private List<SvjedokInfo> svjedoci;
+
+    /** Osumnjičeni vezani za slučaj. */
     private List<OsumnjiceniInfo> osumnjiceni;
+
+    /** Krivična djela vezana za slučaj. */
     private List<KrivicnoDjeloInfo> krivicnaDjela;
+
+    /** Forenzički izvještaji vezani za dokaze slučaja. */
     private List<ForenzickiIzvjestajInfo> forenzickiIzvjestaji;
 
     // Getter i Setter
@@ -44,13 +67,28 @@ public class IzvjestajDTO {
     public void setKrivicnaDjela(List<KrivicnoDjeloInfo> krivicnaDjela) { this.krivicnaDjela = krivicnaDjela; }
 
     // Inner klase
+
+    /** Sažeti podaci o slučaju za potrebe izvještaja. */
     public static class SlucajInfo {
+        /** Primarni ključ slučaja. */
         private Long slucajId;
+
+        /** Jedinstveni broj slučaja. */
         private String brojSlucaja;
+
+        /** Tekstualni opis slučaja. */
         private String opis;
+
+        /** Trenutni status slučaja. */
         private String status;
+
+        /** Ime i prezime voditelja slučaja. */
         private String voditeljSlucaja;
+
+        /** Naziv policijske stanice koja vodi slučaj. */
         private String stanica;
+
+        /** Datum i vrijeme kreiranja slučaja. */
         private Timestamp datumKreiranja;
 
         // Getteri i Setteri
@@ -76,14 +114,30 @@ public class IzvjestajDTO {
         public void setDatumKreiranja(Timestamp datumKreiranja) { this.datumKreiranja = datumKreiranja; }
     }
 
+    /** Podaci o jednom dokazu za potrebe izvještaja. */
     public static class DokazInfo {
+        /** Primarni ključ dokaza. */
         private Long dokazId;
+
+        /** Tekstualni opis dokaza. */
         private String opis;
+
+        /** Tip dokaza. */
         private String tipDokaza;
+
+        /** Lokacija pronalaska dokaza. */
         private String lokacijaPronalaska;
+
+        /** Trenutni status dokaza. */
         private String status;
+
+        /** Ime i prezime uposlenika koji je prikupio dokaz. */
         private String prikupioIme;
+
+        /** Datum i vrijeme prikupljanja dokaza. */
         private Timestamp datumPrikupa;
+
+        /** Lista Base64-enkodiranih fotografija dokaza. */
         private List<String> fotografije;
 
         // Getteri i Setteri
@@ -112,16 +166,36 @@ public class IzvjestajDTO {
         public void setFotografije(List<String> fotografije) { this.fotografije = fotografije; }
     }
 
+    /** Jedan unos u lancu nadzora za potrebe izvještaja. */
     public static class LanacNadzoraInfo {
+        /** Primarni ključ unosa u lancu nadzora. */
         private Long unosId;
+
+        /** Opis dokaza koji je predmet primopredaje. */
         private String dokazOpis;
+
+        /** Datum i vrijeme primopredaje. */
         private Timestamp datumPrimopredaje;
+
+        /** Ime i prezime uposlenika koji je predao dokaz. */
         private String predaoIme;
+
+        /** Ime i prezime uposlenika koji je preuzeo dokaz. */
         private String preuzeoIme;
+
+        /** Svrha primopredaje. */
         private String svrhaPrimopredaje;
+
+        /** Status potvrde primopredaje. */
         private String potvrdaStatus;
+
+        /** Napomena uz potvrdu primopredaje. */
         private String potvrdaNapomena;
+
+        /** Datum i vrijeme potvrde primopredaje. */
         private Timestamp potvrdaDatum;
+
+        /** Ime i prezime uposlenika koji je potvrdio primopredaju. */
         private String potvrdioIme;
 
         // Getteri i Setteri (dodaj sve)
@@ -156,11 +230,21 @@ public class IzvjestajDTO {
         public void setPotvrdioIme(String potvrdioIme) { this.potvrdioIme = potvrdioIme; }
     }
 
+    /** Jedan član tima za potrebe izvještaja. */
     public static class TimInfo {
+        /** Ime i prezime člana tima. */
         private String imePrezime;
+
+        /** Naziv sistemske uloge člana tima (npr. "INSPEKTOR"). */
         private String nazivUloge;
+
+        /** Uloga člana na ovom konkretnom slučaju. */
         private String ulogaNaSlucaju;
+
+        /** Email adresa člana tima. */
         private String email;
+
+        /** Broj značke člana tima. */
         private String brojZnacke;
 
         // Getteri i Setteri
@@ -180,11 +264,21 @@ public class IzvjestajDTO {
         public void setBrojZnacke(String brojZnacke) { this.brojZnacke = brojZnacke; }
     }
 
+    /** Jedan svjedok za potrebe izvještaja. */
     public static class SvjedokInfo {
+        /** Ime i prezime svjedoka. */
         private String imePrezime;
+
+        /** Jedinstveni matični broj građana svjedoka. */
         private String jmbg;
+
+        /** Adresa stanovanja svjedoka. */
         private String adresa;
+
+        /** Kontakt telefon svjedoka. */
         private String kontaktTelefon;
+
+        /** Bilješka o svjedoku ili iskazu. */
         private String biljeska;
 
         // Getteri i Setteri
@@ -204,12 +298,24 @@ public class IzvjestajDTO {
         public void setBiljeska(String biljeska) { this.biljeska = biljeska; }
     }
 
+    /** Jedan osumnjičeni za potrebe izvještaja. */
     public static class OsumnjiceniInfo {
+        /** Primarni ključ osumnjičenog. */
         private Long osumnjiceniId;
+
+        /** Ime i prezime osumnjičenog. */
         private String imePrezime;
+
+        /** Jedinstveni matični broj građana osumnjičenog. */
         private String jmbg;
+
+        /** Datum rođenja osumnjičenog. */
         private Date datumRodjenja;
+
+        /** Adresa stanovanja osumnjičenog. */
         private String adresa;
+
+        /** Lista Base64-enkodiranih fotografija osumnjičenog. */
         private List<String> fotografije;
 
         // Getteri i Setteri
@@ -232,9 +338,15 @@ public class IzvjestajDTO {
         public void setFotografije(List<String> fotografije) { this.fotografije = fotografije; }
     }
 
+    /** Jedno krivično djelo za potrebe izvještaja. */
     public static class KrivicnoDjeloInfo {
+        /** Naziv krivičnog djela. */
         private String naziv;
+
+        /** Kategorija krivičnog djela. */
         private String kategorija;
+
+        /** Član kaznenog zakona koji reguliše ovo djelo. */
         private String kazneniZakonClan;
 
         // Getteri i Setteri
@@ -248,13 +360,27 @@ public class IzvjestajDTO {
         public void setKazneniZakonClan(String kazneniZakonClan) { this.kazneniZakonClan = kazneniZakonClan; }
     }
 
+    /** Jedan forenzički izvještaj za potrebe izvještaja slučaja. */
     public static class ForenzickiIzvjestajInfo {
+        /** Primarni ključ forenzičkog izvještaja. */
         private Long izvjestajId;
+
+        /** ID dokaza na koji se izvještaj odnosi. */
         private Long dokazId;
+
+        /** Opis dokaza na koji se izvještaj odnosi. */
         private String dokazOpis;
+
+        /** Sadržaj forenzičkog izvještaja. */
         private String sadrzaj;
+
+        /** Zaključak forenzičara. */
         private String zakljucak;
+
+        /** Datum i vrijeme kreiranja izvještaja. */
         private java.sql.Timestamp datumKreiranja;
+
+        /** Ime i prezime forenzičara koji je kreirao izvještaj. */
         private String kreatorIme;
 
         // Getteri i Setteri

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/KreirajDokazRequest.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/KreirajDokazRequest.java
@@ -4,10 +4,21 @@ import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
+/**
+ * Tijelo zahtjeva za POST /api/slucajevi/{caseId}/dokazi.
+ *
+ * <p>JSON polja se šalju u snake_case formatu zahvaljujući
+ * {@code @JsonNaming(SnakeCaseStrategy.class)}.
+ */
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class KreirajDokazRequest {
+    /** Tekstualni opis dokaza. */
     private String opis;
+
+    /** Lokacija na kojoj je dokaz pronađen. */
     private String lokacijaPronalaska;
+
+    /** Tip dokaza (npr. "FIZIČKI", "DIGITALNI", "BIOLOŠKI"). */
     private String tipDokaza;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/KreirajSlucajRequest.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/KreirajSlucajRequest.java
@@ -4,22 +4,48 @@ import lombok.Data;
 
 import java.util.List;
 
+/**
+ * Tijelo zahtjeva za POST /api/slucajevi.
+ *
+ * <p>Kreira novi krivični slučaj s adresom mjesta događaja i inicijalnim
+ * sastavom tima. Svaki član tima navodi se kao {@link ClanTima} s ulogom
+ * na slučaju.
+ */
 @Data
 public class KreirajSlucajRequest {
+    /** Jedinstveni broj slučaja (npr. "KT-2024-001"). */
     private String brojSlucaja;
+
+    /** Tekstualni opis slučaja. */
     private String opis;
+
+    /** ID stanice koja vodi slučaj. */
     private Long stanicaId;
 
+    /** Ulica i kućni broj mjesta događaja. */
     private String ulicaIBroj;
+
+    /** Grad mjesta događaja. */
     private String grad;
+
+    /** Poštanski broj mjesta događaja. */
     private String postanskiBroj;
+
+    /** Država mjesta događaja. */
     private String drzava;
 
+    /** Inicijalni sastav tima dodjeljenog slučaju. */
     private List<ClanTima> tim;
 
+    /**
+     * Jedan član tima koji se dodjeljuje slučaju pri kreiranju.
+     */
     @Data
     public static class ClanTima {
+        /** ID korisnika (NBP_USER) koji se dodaje u tim. */
         private Long userId;
+
+        /** Uloga člana na ovom slučaju (npr. "VODITELJ", "ISTRAŽITELJ"). */
         private String uloga;
     }
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/KreirajSvjedokaRequest.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/KreirajSvjedokaRequest.java
@@ -4,12 +4,26 @@ import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
+/**
+ * Tijelo zahtjeva za POST /api/slucajevi/{id}/svjedoci ili POST /api/svjedoci.
+ *
+ * <p>Kreira novog svjedoka i vezuje ga za slučaj. JSON polja su u snake_case formatu.
+ */
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class KreirajSvjedokaRequest {
+    /** Puno ime i prezime svjedoka. */
     private String imePrezime;
+
+    /** Jedinstveni matični broj građana svjedoka. */
     private String jmbg;
+
+    /** Adresa stanovanja svjedoka. */
     private String adresa;
+
+    /** Kontakt telefon svjedoka. */
     private String kontaktTelefon;
+
+    /** Dodatne bilješke o svjedoku ili iskazu. */
     private String biljeska;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/LanacDetaljiDTO.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/LanacDetaljiDTO.java
@@ -6,16 +6,39 @@ import lombok.Data;
 
 import java.sql.Timestamp;
 
+/**
+ * Odgovor za GET /api/dokazi/{id}/lanac-nadzora.
+ *
+ * <p>Detalji jednog unosa u lancu nadzora dokaza, uključujući informacije
+ * o primopredaji i statusu potvrde. JSON polja su u snake_case formatu.
+ */
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class LanacDetaljiDTO {
+    /** Primarni ključ unosa u lancu nadzora. */
     private Long unosId;
+
+    /** Datum i vrijeme primopredaje dokaza. */
     private Timestamp datumPrimopredaje;
+
+    /** Ime i prezime uposlenika koji je predao dokaz. */
     private String predaoIme;
+
+    /** Ime i prezime uposlenika koji je preuzeo dokaz. */
     private String preuzeoIme;
+
+    /** Svrha primopredaje dokaza. */
     private String svrhaPrimopredaje;
+
+    /** Status potvrde primopredaje (npr. "POTVRĐENO", "NA_ČEKANJU", "ODBIJENO"). */
     private String potvrdaStatus;
+
+    /** Napomena primaoca uz potvrdu ili odbijanje primopredaje. */
     private String potvrdaNapomena;
+
+    /** Datum i vrijeme potvrde ili odbijanja primopredaje. */
     private Timestamp potvrdaDatum;
+
+    /** Ime i prezime uposlenika koji je potvrdio ili odbio primopredaju. */
     private String potvrdioIme;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/LoginRequest.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/LoginRequest.java
@@ -2,9 +2,20 @@ package ba.unsa.etf.suds.dto;
 
 import lombok.Data;
 
+/**
+ * Tijelo zahtjeva za POST /api/auth/login.
+ *
+ * <p>Identitet se utvrđuje kombinacijom (email, brojZnacke), a lozinka se
+ * provjerava preko BCrypt-a. Pogledati AuthService#login.
+ */
 @Data
 public class LoginRequest {
+    /** Email adresa uposlenika. */
     private String email;
+
+    /** Lozinka u plain-text obliku (BCrypt provjera radi server). */
     private String password;
+
+    /** Broj značke — razlikuje uposlenike s istim email-om u različitim stanicama. */
     private String brojZnacke;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/LoginResponse.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/LoginResponse.java
@@ -3,9 +3,18 @@ package ba.unsa.etf.suds.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+/**
+ * Odgovor servera na POST /api/auth/login.
+ *
+ * <p>Sadrži JWT token koji klijent treba pohraniti i slati u
+ * {@code Authorization: Bearer <token>} zaglavlju svakog zahtjeva.
+ */
 @Data
 @AllArgsConstructor
 public class LoginResponse {
+    /** JWT token koji identificira prijavljenog uposlenika. */
     private String token;
+
+    /** Tip tokena — uvijek {@code "Bearer"}. */
     private String type = "Bearer";
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/MojSlucajDTO.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/MojSlucajDTO.java
@@ -6,14 +6,34 @@ import lombok.Data;
 
 import java.sql.Timestamp;
 
+/**
+ * Odgovor za GET /api/slucajevi/moji.
+ *
+ * <p>Sažeti prikaz slučaja u kojemu je prijavljeni uposlenik član tima.
+ * Uključuje ulogu uposlenika na konkretnom slučaju.
+ * JSON polja su u snake_case formatu.
+ */
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class MojSlucajDTO {
+    /** Primarni ključ slučaja. */
     private Long slucajId;
+
+    /** Jedinstveni broj slučaja. */
     private String brojSlucaja;
+
+    /** Tekstualni opis slučaja. */
     private String opis;
+
+    /** Trenutni status slučaja. */
     private String status;
+
+    /** Ime i prezime voditelja slučaja. */
     private String voditeljSlucaja;
+
+    /** Uloga prijavljenog uposlenika na ovom slučaju. */
     private String ulogaNaSlucaju;
+
+    /** Datum i vrijeme kreiranja slučaja. */
     private Timestamp datumKreiranja;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/MojaPrimopredajaDTO.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/MojaPrimopredajaDTO.java
@@ -6,15 +6,37 @@ import lombok.Data;
 
 import java.sql.Timestamp;
 
+/**
+ * Odgovor za GET /api/primopredaje/moje.
+ *
+ * <p>Prikazuje primopredaje u kojima je prijavljeni uposlenik bio pošiljalac.
+ * Uključuje proteklo vrijeme od primopredaje radi praćenja rokova.
+ * JSON polja su u snake_case formatu.
+ */
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class MojaPrimopredajaDTO {
+    /** Primarni ključ unosa u lancu nadzora. */
     private Long unosId;
+
+    /** Opis dokaza koji je predmet primopredaje. */
     private String dokazOpis;
+
+    /** Tip dokaza koji je predmet primopredaje. */
     private String tipDokaza;
+
+    /** Ime i prezime uposlenika koji je preuzeo dokaz. */
     private String preuzeoIme;
+
+    /** Svrha primopredaje dokaza. */
     private String svrhaPrimopredaje;
+
+    /** Datum i vrijeme primopredaje. */
     private Timestamp datumPrimopredaje;
+
+    /** ID dokaza koji je predmet primopredaje. */
     private Long dokazId;
+
+    /** Broj sekundi koji je protekao od primopredaje. */
     private Long protekloSekundi;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/OsumnjiceniDTO.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/OsumnjiceniDTO.java
@@ -5,13 +5,28 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.sql.Date;
 
+/**
+ * Odgovor za GET /api/slucajevi/{id}/osumnjiceni i GET /api/osumnjiceni/{id}.
+ *
+ * <p>Sažeti podaci o osumnjičenom bez fotografija. Za fotografije koristiti
+ * {@link OsumnjiceniFotografijaDTO}.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class OsumnjiceniDTO {
+    /** Primarni ključ osumnjičenog iz tabele OSUMNJICENI. */
     private Long osumnjiceniId;
+
+    /** Puno ime i prezime osumnjičenog. */
     private String imePrezime;
+
+    /** Jedinstveni matični broj građana osumnjičenog. */
     private String jmbg;
-    private String adresa; 
+
+    /** Adresa stanovanja osumnjičenog. */
+    private String adresa;
+
+    /** Datum rođenja osumnjičenog. */
     private Date datumRodjenja;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/OsumnjiceniFotografijaDTO.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/OsumnjiceniFotografijaDTO.java
@@ -5,22 +5,53 @@ import lombok.Setter;
 
 import java.sql.Timestamp;
 
+/**
+ * Odgovor za GET /api/osumnjiceni/{id}/fotografije.
+ *
+ * <p>Predstavlja jednu fotografiju osumnjičenog s Base64-enkodiranim sadržajem
+ * pogodnim za direktno prikazivanje u SPA-u. Uključuje podatke o izmjenama
+ * radi revizijskog traga.
+ */
 @Setter
 @Getter
 public class OsumnjiceniFotografijaDTO {
-    // Getteri i setteri
+    /** Primarni ključ fotografije iz tabele FOTOGRAFIJE_OSUMNJICENIH. */
     private Long fotografijaId;
+
+    /** ID osumnjičenog kojemu fotografija pripada. */
     private Long osumnjiceniId;
+
+    /** Base64-enkodirana slika za direktno prikazivanje u frontendu. */
     private String fotografijaBase64;
+
+    /** Originalni naziv fajla fotografije. */
     private String nazivFajla;
+
+    /** MIME tip fotografije (npr. "image/jpeg"). */
     private String mimeType;
+
+    /** Veličina fajla u bajtovima. */
     private Long velicinaFajla;
+
+    /** Redni broj fotografije unutar skupa fotografija osumnjičenog. */
     private Integer redniBroj;
+
+    /** Datum i vrijeme dodavanja fotografije. */
     private Timestamp datumDodavanja;
+
+    /** Ime i prezime uposlenika koji je dodao fotografiju. */
     private String dodaoIme;
+
+    /** Datum i vrijeme posljednje izmjene fotografije. */
     private Timestamp datumIzmjene;
+
+    /** Ime i prezime uposlenika koji je posljednji izmijenio fotografiju. */
     private String izmijenioIme;
+
+    /** Tekstualni opis sadržaja fotografije. */
     private String opisFotografije;
+
+    /** Status fotografije (npr. "AKTIVAN", "ARHIVIRAN"). */
     private String status;
 
     // Konstruktori

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/PonistiRequest.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/PonistiRequest.java
@@ -4,8 +4,15 @@ import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
+/**
+ * Tijelo zahtjeva za DELETE /api/primopredaje/{unosId}/ponisti.
+ *
+ * <p>Poništava primopredaju koja još nije potvrđena. Razlog poništavanja
+ * se bilježi u sistemu. JSON polja su u snake_case formatu.
+ */
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PonistiRequest {
+    /** Razlog poništavanja primopredaje. */
     private String razlog;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/PosaljiDokazRequest.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/PosaljiDokazRequest.java
@@ -2,10 +2,23 @@ package ba.unsa.etf.suds.dto;
 
 import lombok.Data;
 
+/**
+ * Tijelo zahtjeva za POST /api/lanac-nadzora/posalji.
+ *
+ * <p>Inicira primopredaju dokaza drugom uposleniku. Primalac mora
+ * potvrditi primopredaju putem {@link PotvrdaRequest}.
+ */
 @Data
 public class PosaljiDokazRequest {
+    /** ID dokaza koji se predaje. */
     private Long dokazId;
+
+    /** ID uposlenika (NBP_USER) koji preuzima dokaz. */
     private Long primaocUserId;
+
+    /** ID stanice primaoca. */
     private Long stanicaId;
+
+    /** Svrha primopredaje dokaza. */
     private String svrhaPrimopredaje;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/PotvrdaRequest.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/PotvrdaRequest.java
@@ -4,9 +4,18 @@ import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
+/**
+ * Tijelo zahtjeva za PATCH /api/lanac-nadzora/{unosId}/potvrda.
+ *
+ * <p>Primalac dokaza potvrđuje ili odbija primopredaju. Napomena je
+ * obavezna pri odbijanju. JSON polja su u snake_case formatu.
+ */
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PotvrdaRequest {
+    /** Status potvrde: "POTVRĐENO" ili "ODBIJENO". */
     private String status;
+
+    /** Napomena primaoca uz potvrdu ili odbijanje primopredaje. */
     private String napomena;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/PrimopredajaRequest.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/PrimopredajaRequest.java
@@ -4,9 +4,18 @@ import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
+/**
+ * Tijelo zahtjeva za POST /api/dokazi/{id}/primopredaja.
+ *
+ * <p>Inicira primopredaju dokaza direktno s ID-om dokaza u putanji.
+ * JSON polja su u snake_case formatu.
+ */
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PrimopredajaRequest {
+    /** ID uposlenika koji preuzima dokaz. */
     private Long preuzeoUposlenikId;
+
+    /** Svrha primopredaje dokaza. */
     private String svrha;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/PrimopredajaZaPotvrduDTO.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/PrimopredajaZaPotvrduDTO.java
@@ -6,14 +6,33 @@ import lombok.Data;
 
 import java.sql.Timestamp;
 
+/**
+ * Odgovor za GET /api/primopredaje/za-potvrdu.
+ *
+ * <p>Prikazuje primopredaje koje čekaju potvrdu od strane prijavljenog uposlenika
+ * (primopredaje u kojima je on primalac). JSON polja su u snake_case formatu.
+ */
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PrimopredajaZaPotvrduDTO {
+    /** Primarni ključ unosa u lancu nadzora. */
     private Long unosId;
+
+    /** Opis dokaza koji je predmet primopredaje. */
     private String dokazOpis;
+
+    /** Tip dokaza koji je predmet primopredaje. */
     private String tipDokaza;
+
+    /** Ime i prezime uposlenika koji je predao dokaz. */
     private String predaoIme;
+
+    /** Svrha primopredaje dokaza. */
     private String svrhaPrimopredaje;
+
+    /** Datum i vrijeme primopredaje. */
     private Timestamp datumPrimopredaje;
+
+    /** ID dokaza koji je predmet primopredaje. */
     private Long dokazId;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/PromijeniStatusRequest.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/PromijeniStatusRequest.java
@@ -2,7 +2,13 @@ package ba.unsa.etf.suds.dto;
 
 import lombok.Data;
 
+/**
+ * Tijelo zahtjeva za PATCH /api/uposlenici/{id}/status.
+ *
+ * <p>Šef stanice mijenja radni status uposlenika.
+ */
 @Data
 public class PromijeniStatusRequest {
-    private String status; // "Aktivan", "Penzionisan", "Otpušten"
+    /** Novi status uposlenika: "Aktivan", "Penzionisan" ili "Otpušten". */
+    private String status;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/RegistrationRequest.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/RegistrationRequest.java
@@ -2,17 +2,45 @@ package ba.unsa.etf.suds.dto;
 
 import lombok.Data;
 
+/**
+ * Tijelo zahtjeva za POST /api/stanice/register.
+ *
+ * <p>Registrira novu policijsku stanicu zajedno s prvim korisnikom
+ * (šefom stanice). Adresa stanice može se proslijediti kao slobodna
+ * polja ili kao referenca na postojeću adresu putem {@code adresaId}.
+ */
 @Data
 public class RegistrationRequest {
+    /** Naziv policijske stanice koja se registrira. */
     private String imeStanice;
+
+    /** Ulica i kućni broj sjedišta stanice. */
     private String ulicaIBroj;
-    private String grad;       
-    private String postanskiBroj; 
+
+    /** Grad u kojem se stanica nalazi. */
+    private String grad;
+
+    /** Poštanski broj sjedišta stanice. */
+    private String postanskiBroj;
+
+    /** Ime šefa stanice (prvog korisnika). */
     private String firstName;
+
+    /** Prezime šefa stanice (prvog korisnika). */
     private String lastName;
+
+    /** Email adresa šefa stanice. */
     private String email;
+
+    /** Lozinka šefa stanice u plain-text obliku. */
     private String password;
+
+    /** Korisničko ime šefa stanice. */
     private String username;
+
+    /** Broj značke šefa stanice. */
     private String brojZnacke;
-    private Long adresaId; 
+
+    /** ID postojeće adrese iz tabele ADRESE (alternativa slobodnim poljima). */
+    private Long adresaId;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/SlucajDetaljiDTO.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/SlucajDetaljiDTO.java
@@ -3,11 +3,26 @@ package ba.unsa.etf.suds.dto;
 import lombok.Data;
 import java.util.List;
 
+/**
+ * Odgovor za GET /api/slucajevi/{brojSlucaja}.
+ *
+ * <p>Detalji jednog slučaja s imenima osumnjičenih i krivičnih djela
+ * agregiranim iz JOIN upita. Namijenjen prikazu detalja slučaja u SPA-u.
+ */
 @Data
 public class SlucajDetaljiDTO {
+    /** Jedinstveni broj slučaja. */
     private String brojSlucaja;
+
+    /** Tekstualni opis slučaja. */
     private String opis;
-    private String imeInspektora; // Voditelj slučaja (FIRST_NAME + LAST_NAME)
-    private List<String> osumnjiceni; // Lista ime_prezime iz tabele Osumnjiceni
-    private List<String> krivicnaDjela; // Nazivi djela iz Krivicna_Djela
+
+    /** Ime i prezime voditelja slučaja (FIRST_NAME + LAST_NAME iz NBP_USER). */
+    private String imeInspektora;
+
+    /** Lista punih imena osumnjičenih vezanih za slučaj. */
+    private List<String> osumnjiceni;
+
+    /** Lista naziva krivičnih djela vezanih za slučaj. */
+    private List<String> krivicnaDjela;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/SlucajListDTO.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/SlucajListDTO.java
@@ -6,13 +6,30 @@ import lombok.Data;
 
 import java.sql.Timestamp;
 
+/**
+ * Odgovor za GET /api/slucajevi.
+ *
+ * <p>Sažeti prikaz jednog slučaja namijenjen listama u SPA-u.
+ * JSON polja su u snake_case formatu.
+ */
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SlucajListDTO {
+    /** Primarni ključ slučaja. */
     private Long slucajId;
+
+    /** Jedinstveni broj slučaja. */
     private String brojSlucaja;
+
+    /** Tekstualni opis slučaja. */
     private String opis;
+
+    /** Trenutni status slučaja. */
     private String status;
+
+    /** Ime i prezime voditelja slučaja. */
     private String voditeljSlucaja;
+
+    /** Datum i vrijeme kreiranja slučaja. */
     private Timestamp datumKreiranja;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/SvjedokDTO.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/SvjedokDTO.java
@@ -6,15 +6,31 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * Odgovor za GET /api/slucajevi/{id}/svjedoci i GET /api/svjedoci/{id}.
+ *
+ * <p>Sažeti podaci o svjedoku. JSON polja su u snake_case formatu.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SvjedokDTO {
+    /** Primarni ključ svjedoka iz tabele SVJEDOCI. */
     private Long svjedokId;
+
+    /** Puno ime i prezime svjedoka. */
     private String imePrezime;
+
+    /** Kontakt telefon svjedoka. */
     private String kontaktTelefon;
+
+    /** Adresa stanovanja svjedoka. */
     private String adresa;
+
+    /** Jedinstveni matični broj građana svjedoka. */
     private String jmbg;
+
+    /** Bilješka o svjedoku ili iskazu. */
     private String biljeska;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/TimClanDTO.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/TimClanDTO.java
@@ -4,14 +4,33 @@ import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
+/**
+ * Odgovor za GET /api/slucajevi/{id}/tim.
+ *
+ * <p>Podaci o jednom članu tima dodjeljenog slučaju.
+ * JSON polja su u snake_case formatu.
+ */
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TimClanDTO {
+    /** Primarni ključ dodjele iz tabele SLUCAJ_TIM. */
     private Long dodjelaId;
+
+    /** ID uposlenika (NBP_USER). */
     private Long uposlenikId;
+
+    /** Puno ime i prezime uposlenika. */
     private String imePrezime;
+
+    /** Naziv sistemske uloge uposlenika (npr. "INSPEKTOR"). */
     private String nazivUloge;
+
+    /** Uloga uposlenika na ovom konkretnom slučaju. */
     private String ulogaNaSlucaju;
+
+    /** Broj značke uposlenika. */
     private String brojZnacke;
+
+    /** Email adresa uposlenika. */
     private String email;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/UpdateStatusRequest.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/UpdateStatusRequest.java
@@ -4,8 +4,15 @@ import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
+/**
+ * Tijelo zahtjeva za PATCH /api/dokazi/{id}/status.
+ *
+ * <p>Ažurira status dokaza u lancu nadzora.
+ * JSON polja su u snake_case formatu.
+ */
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class UpdateStatusRequest {
+    /** Novi status dokaza (npr. "U_LABORATORIJI", "NA_ČUVANJU", "VRAĆEN"). */
     private String status;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/UposlenikDTO.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/UposlenikDTO.java
@@ -5,18 +5,42 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * Odgovor za GET /api/uposlenici i GET /api/uposlenici/{id}.
+ *
+ * <p>Podaci o uposleniku s prilagođenim JSON imenima polja putem
+ * {@code @JsonProperty} anotacija. Metoda {@link #getUloga()} mapira
+ * interne nazive uloga (npr. "SEF_STANICE") u čitljive nazive za SPA.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class UposlenikDTO {
+    /** Primarni ključ korisnika iz tabele NBP_USER. */
     private Long userId;
+
+    /** Ime uposlenika. */
     private String ime;
+
+    /** Prezime uposlenika. */
     private String prezime;
+
+    /** Email adresa uposlenika. */
     private String email;
+
+    /** Korisničko ime uposlenika. */
     private String username;
-    private String nazivUloge;     // Iz NBP_ROLE (DB vrijednost, npr. "SEF_STANICE")
-    private String brojZnacke;     // Iz UPOSLENIK_PROFIL
-    private String nazivStanice;   // Iz STANICE
+
+    /** Naziv uloge iz tabele NBP_ROLE (interna vrijednost, npr. "SEF_STANICE"). */
+    private String nazivUloge;
+
+    /** Broj značke uposlenika iz tabele UPOSLENIK_PROFIL. */
+    private String brojZnacke;
+
+    /** Naziv policijske stanice kojoj uposlenik pripada. */
+    private String nazivStanice;
+
+    /** Radni status uposlenika (npr. "Aktivan", "Penzionisan"). */
     private String status;
 
     @JsonProperty("uposlenik_id")

--- a/suds/src/main/java/ba/unsa/etf/suds/dto/UposlenikLoginDTO.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/dto/UposlenikLoginDTO.java
@@ -3,16 +3,40 @@ package ba.unsa.etf.suds.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+/**
+ * Interni DTO koji AuthService koristi za dohvat korisničkih podataka pri prijavi.
+ *
+ * <p>Nije direktno izložen kao HTTP odgovor — koristi se interno između
+ * repozitorija i servisa za autentifikaciju. Sadrži hashiranu lozinku
+ * potrebnu za BCrypt provjeru.
+ */
 @Data
 @AllArgsConstructor
 public class UposlenikLoginDTO {
+    /** Primarni ključ korisnika iz tabele NBP_USER. */
     private Long userId;
+
+    /** Ime uposlenika. */
     private String ime;
+
+    /** Prezime uposlenika. */
     private String prezime;
+
+    /** Email adresa uposlenika. */
     private String email;
+
+    /** BCrypt-hashirana lozinka uposlenika. */
     private String password;
+
+    /** Naziv sistemske uloge uposlenika (npr. "INSPEKTOR"). */
     private String uloga;
+
+    /** Broj značke uposlenika. */
     private String brojZnacke;
+
+    /** Radni status uposlenika. */
     private String status;
+
+    /** ID policijske stanice kojoj uposlenik pripada. */
     private Long stanicaId;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/model/Adresa.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/Adresa.java
@@ -4,13 +4,26 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * POJO koji reprezentira jedan red u tabeli ADRESE — fizička adresa koja se
+ * koristi kao FK u tabelama STANICE, OSUMNJICENI i nbp.NBP_USER.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class Adresa {
+    /** Primarni ključ — kolona ADRESA_ID. */
     private Long adresaId;
+
+    /** Naziv ulice i kućni broj — kolona ULICA_I_BROJ. */
     private String ulicaIBroj;
+
+    /** Naziv grada — kolona GRAD. */
     private String grad;
+
+    /** Poštanski broj — kolona POSTANSKI_BROJ. */
     private String postanskiBroj;
+
+    /** Naziv države — kolona DRZAVA. */
     private String drzava;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/model/CrnaListaTokena.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/CrnaListaTokena.java
@@ -5,11 +5,21 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.sql.Timestamp;
 
+/**
+ * POJO koji reprezentira jedan red u tabeli nbp.CRNA_LISTA_TOKENA — JWT tokeni
+ * koji su eksplicitno poništeni (odjava korisnika) i ne smiju se više prihvatiti,
+ * čak i ako im rok važenja još nije istekao.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class CrnaListaTokena {
+    /** Primarni ključ — kolona ID. */
     private Long id;
+
+    /** Cijeli JWT string koji je stavljen na crnu listu — kolona TOKEN. */
     private String token;
+
+    /** Datum i vrijeme kada token ističe; nakon toga se red može obrisati — kolona EXPIRES_AT. */
     private Timestamp expiresAt;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/model/Dokaz.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/Dokaz.java
@@ -6,17 +6,42 @@ import lombok.NoArgsConstructor;
 
 import java.sql.Timestamp;
 
+/**
+ * POJO koji reprezentira jedan red u tabeli DOKAZI — fizički ili digitalni dokaz
+ * prikupljen u okviru krivičnog slučaja.
+ *
+ * <p>Veže se na: SLUCAJEVI (kroz SLUCAJ_ID), STANICE (kroz STANICA_ID),
+ * nbp.NBP_USER (kroz PRIKUPIO_USER_ID). Nadređeni entitet za LANAC_NADZORA,
+ * FORENZICKI_IZVJESTAJI i DOKAZ_FOTOGRAFIJE.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class Dokaz {
+    /** Primarni ključ — kolona DOKAZ_ID. */
     private Long dokazId;
+
+    /** FK na SLUCAJEVI.SLUCAJ_ID — slučaj kome dokaz pripada — kolona SLUCAJ_ID. */
     private Long slucajId;
+
+    /** FK na STANICE.STANICA_ID — stanica koja čuva dokaz — kolona STANICA_ID. */
     private Long stanicaId;
+
+    /** Tekstualni opis dokaza — kolona OPIS. */
     private String opis;
+
+    /** Lokacija na kojoj je dokaz pronađen — kolona LOKACIJA_PRONALASKA. */
     private String lokacijaPronalaska;
+
+    /** Tip dokaza (npr. "Fizički", "Digitalni", "Biološki") — kolona TIP_DOKAZA. */
     private String tipDokaza;
+
+    /** Trenutni status dokaza u lancu nadzora — kolona STATUS. */
     private String status;
+
+    /** Datum i vrijeme prikupljanja dokaza — kolona DATUM_PRIKUPA. */
     private Timestamp datumPrikupa;
+
+    /** FK na nbp.NBP_USER.ID — korisnik koji je prikupio dokaz — kolona PRIKUPIO_USER_ID. */
     private Long prikupioUserId;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/model/DokazFotografija.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/DokazFotografija.java
@@ -5,19 +5,45 @@ import lombok.Setter;
 
 import java.sql.Timestamp;
 
+/**
+ * POJO koji reprezentira jedan red u tabeli DOKAZ_FOTOGRAFIJE — fotografija
+ * priložena uz određeni dokaz u krivičnom predmetu.
+ *
+ * <p>Veže se na: DOKAZI (kroz DOKAZ_ID), nbp.NBP_USER (kroz DODAO_USER_ID).
+ * Polje {@code fotografija} je BLOB kolona; preporučena maksimalna veličina
+ * fajla je 10 MB (ograničenje na nivou servisa).
+ */
 @Setter
 @Getter
 public class DokazFotografija {
-    // Getteri i setteri
+    /** Primarni ključ — kolona FOTOGRAFIJA_ID. */
     private Long fotografijaId;
+
+    /** FK na DOKAZI.DOKAZ_ID — dokaz kome fotografija pripada — kolona DOKAZ_ID. */
     private Long dokazId;
+
+    /** Binarni sadržaj fotografije (BLOB) — kolona FOTOGRAFIJA. */
     private byte[] fotografija;
+
+    /** Originalni naziv fajla pri uploadu — kolona NAZIV_FAJLA. */
     private String nazivFajla;
+
+    /** MIME tip fajla (npr. "image/jpeg", "image/png") — kolona MIME_TYPE. */
     private String mimeType;
+
+    /** Veličina fajla u bajtovima — kolona VELICINA_FAJLA. */
     private Long velicinaFajla;
+
+    /** Redni broj fotografije unutar skupa fotografija jednog dokaza — kolona REDNI_BROJ. */
     private Integer redniBroj;
+
+    /** Datum i vrijeme dodavanja fotografije — kolona DATUM_DODAVANJA. */
     private Timestamp datumDodavanja;
+
+    /** FK na nbp.NBP_USER.ID — korisnik koji je dodao fotografiju — kolona DODAO_USER_ID. */
     private Long dodaoUserId;
+
+    /** Slobodni tekstualni opis sadržaja fotografije — kolona OPIS_FOTOGRAFIJE. */
     private String opisFotografije;
 
     // Konstruktori

--- a/suds/src/main/java/ba/unsa/etf/suds/model/ForenzickiIzvjestaj.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/ForenzickiIzvjestaj.java
@@ -6,14 +6,31 @@ import lombok.NoArgsConstructor;
 
 import java.sql.Timestamp;
 
+/**
+ * POJO koji reprezentira jedan red u tabeli FORENZICKI_IZVJESTAJI — forenzički
+ * izvještaj koji FORENZIČAR kreira za određeni dokaz.
+ *
+ * <p>Veže se na: DOKAZI (kroz DOKAZ_ID), nbp.NBP_USER (kroz KREATOR_USER_ID).
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class ForenzickiIzvjestaj {
+    /** Primarni ključ — kolona IZVJESTAJ_ID. */
     private Long izvjestajId;
+
+    /** FK na DOKAZI.DOKAZ_ID — dokaz na koji se izvještaj odnosi — kolona DOKAZ_ID. */
     private Long dokazId;
+
+    /** FK na nbp.NBP_USER.ID — forenzičar koji je kreirao izvještaj — kolona KREATOR_USER_ID. */
     private Long kreatorUserId;
+
+    /** Detaljan tekstualni sadržaj izvještaja — kolona SADRZAJ. */
     private String sadrzaj;
+
+    /** Sažeti zaključak forenzičke analize — kolona ZAKLJUCAK. */
     private String zakljucak;
+
+    /** Datum i vrijeme kreiranja izvještaja — kolona DATUM_KREIRANJA. */
     private Timestamp datumKreiranja;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/model/KrivicnoDjelo.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/KrivicnoDjelo.java
@@ -4,12 +4,25 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * POJO koji reprezentira jedan red u tabeli KRIVICNA_DJELA — katalog krivičnih
+ * djela prema Kaznenom zakonu BiH.
+ *
+ * <p>Veže se na slučajeve kroz veznu tabelu SLUCAJ_KRIVICNO_DJELO.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class KrivicnoDjelo {
+    /** Primarni ključ — kolona DJELO_ID. */
     private Long id; // U bazi je ovo DJELO_ID
+
+    /** Naziv krivičnog djela — kolona NAZIV. */
     private String naziv;
+
+    /** Kategorija krivičnog djela (npr. "Imovinski", "Nasilnički") — kolona KATEGORIJA. */
     private String kategorija;
+
+    /** Član Kaznenog zakona koji propisuje djelo — kolona KAZNENI_ZAKON_CLAN. */
     private String kazneniZakonClan; // U bazi je KAZNENI_ZAKON_CLAN
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/model/LanacNadzora.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/LanacNadzora.java
@@ -6,19 +6,48 @@ import lombok.NoArgsConstructor;
 
 import java.sql.Timestamp;
 
+/**
+ * POJO koji reprezentira jedan red u tabeli LANAC_NADZORA — nepromjenjivi zapis
+ * o primopredaji dokaza između uposlenika (chain of custody).
+ *
+ * <p>Veže se na: DOKAZI (kroz DOKAZ_ID), STANICE (kroz STANICA_ID),
+ * nbp.NBP_USER (kroz PREDAO_USER_ID, PREUZEO_USER_ID i POTVRDIO_USER_ID).
+ * Svaka primopredaja zahtijeva eksplicitnu potvrdu primaoca.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class LanacNadzora {
+    /** Primarni ključ — kolona UNOS_ID. */
     private Long unosId;
+
+    /** FK na DOKAZI.DOKAZ_ID — dokaz koji se predaje — kolona DOKAZ_ID. */
     private Long dokazId;
+
+    /** FK na STANICE.STANICA_ID — stanica na kojoj se primopredaja odvija — kolona STANICA_ID. */
     private Long stanicaId;
+
+    /** Datum i vrijeme primopredaje — kolona DATUM_PRIMOPREDAJE. */
     private Timestamp datumPrimopredaje;
+
+    /** FK na nbp.NBP_USER.ID — korisnik koji predaje dokaz — kolona PREDAO_USER_ID. */
     private Long predaoUserId;
+
+    /** FK na nbp.NBP_USER.ID — korisnik koji preuzima dokaz — kolona PREUZEO_USER_ID. */
     private Long preuzeoUserId;
+
+    /** Razlog ili svrha primopredaje — kolona SVRHA_PRIMOPREDAJE. */
     private String svrhaPrimopredaje;
+
+    /** Status potvrde primopredaje (npr. "CEKA", "POTVRDJENO", "ODBIJENO") — kolona POTVRDA_STATUS. */
     private String potvrdaStatus;
+
+    /** Opcionalna napomena uz potvrdu ili odbijanje — kolona POTVRDA_NAPOMENA. */
     private String potvrdaNapomena;
+
+    /** Datum i vrijeme kada je potvrda data — kolona POTVRDA_DATUM. */
     private Timestamp potvrdaDatum;
+
+    /** FK na nbp.NBP_USER.ID — korisnik koji je potvrdio primopredaju — kolona POTVRDIO_USER_ID. */
     private Long potvrdioUserId;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/model/NbpLog.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/NbpLog.java
@@ -5,13 +5,28 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.sql.Timestamp;
 
+/**
+ * POJO koji reprezentira jedan red u tabeli nbp.NBP_LOG — audit log koji bilježi
+ * DML operacije (INSERT, UPDATE, DELETE) nad tabelama u bazi podataka.
+ *
+ * <p>Popunjava se automatski kroz Oracle triggere; ne upisuje se direktno iz aplikacije.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class NbpLog {
+    /** Primarni ključ — kolona ID. */
     private Long id;
+
+    /** Naziv DML akcije koja je izvršena (npr. "INSERT", "UPDATE") — kolona ACTION_NAME. */
     private String actionName;
+
+    /** Naziv tabele nad kojom je akcija izvršena — kolona TABLE_NAME. */
     private String tableName;
+
+    /** Datum i vrijeme izvršavanja akcije — kolona DATE_TIME. */
     private Timestamp dateTime;
+
+    /** Korisničko ime DB sesije koja je izvršila akciju — kolona DB_USER. */
     private String dbUser;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/model/NbpRole.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/NbpRole.java
@@ -4,10 +4,19 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * POJO koji reprezentira jedan red u tabeli nbp.NBP_ROLE — uloga korisnika
+ * u sistemu (SEF_STANICE, INSPEKTOR, POLICAJAC, FORENZIČAR).
+ *
+ * <p>Veže se na nbp.NBP_USER kroz ROLE_ID.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class NbpRole {
+    /** Primarni ključ — kolona ID. */
     private Long id;
+
+    /** Naziv uloge (npr. "SEF_STANICE", "INSPEKTOR") — kolona NAME. */
     private String name;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/model/NbpUser.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/NbpUser.java
@@ -5,18 +5,45 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.sql.Date; // Koristimo java.sql.Date jer u ERD piše tip 'date'
 
+/**
+ * POJO koji reprezentira jedan red u tabeli nbp.NBP_USER — korisnički nalog
+ * uposlenika koji se prijavljuje u SUDS sistem.
+ *
+ * <p>Veže se na: nbp.NBP_ROLE (kroz ROLE_ID), ADRESE (kroz ADDRESS_ID).
+ * Koristi se kao FK u UPOSLENIK_PROFIL, TIM_NA_SLUCAJU, DOKAZI,
+ * LANAC_NADZORA i FORENZICKI_IZVJESTAJI.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class NbpUser {
+    /** Primarni ključ — kolona ID. */
     private Long id;
+
+    /** Ime korisnika — kolona FIRST_NAME. */
     private String firstName;
+
+    /** Prezime korisnika — kolona LAST_NAME. */
     private String lastName;
+
+    /** E-mail adresa korisnika, mora biti jedinstven — kolona EMAIL. */
     private String email;
+
+    /** Hashirana lozinka korisnika — kolona PASSWORD. */
     private String password;
+
+    /** Korisničko ime za prijavu, mora biti jedinstven — kolona USERNAME. */
     private String username;
+
+    /** Kontakt telefon korisnika — kolona PHONE_NUMBER. */
     private String phoneNumber;
+
+    /** Datum rođenja korisnika — kolona BIRTH_DATE (tip DATE u Oracle). */
     private Date birthDate;
+
+    /** FK na ADRESE.ADRESA_ID — adresa korisnika — kolona ADDRESS_ID. */
     private Long addressId;
+
+    /** FK na nbp.NBP_ROLE.ID — uloga korisnika u sistemu — kolona ROLE_ID. */
     private Long roleId;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/model/Osumnjiceni.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/Osumnjiceni.java
@@ -5,13 +5,29 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.sql.Date;
 
+/**
+ * POJO koji reprezentira jedan red u tabeli OSUMNJICENI — osoba koja je
+ * osumnjičena za jedno ili više krivičnih djela.
+ *
+ * <p>Veže se na: ADRESE (kroz ADRESA_ID). Povezuje se sa slučajevima kroz
+ * veznu tabelu SLUCAJ_OSUMNJICENI. Nadređeni entitet za OSUMNJICENI_FOTOGRAFIJE.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class Osumnjiceni {
+    /** Primarni ključ — kolona OSUMNJICENI_ID. */
     private Long osumnjiceniId; // OSUMNJICENI_ID
+
+    /** Puno ime i prezime osumnjičenog — kolona IME_PREZIME. */
     private String imePrezime;  // IME_PREZIME
+
+    /** Jedinstveni matični broj građana — kolona JMBG. */
     private String jmbg;        // JMBG
+
+    /** FK na ADRESE.ADRESA_ID — adresa stanovanja osumnjičenog — kolona ADRESA_ID. */
     private Long adresaId;      // ADRESA_ID
+
+    /** Datum rođenja osumnjičenog — kolona DATUM_RODJENJA (tip DATE u Oracle). */
     private Date datumRodjenja; // DATUM_RODJENJA
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/model/OsumnjiceniFotografija.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/OsumnjiceniFotografija.java
@@ -5,22 +5,54 @@ import lombok.Setter;
 
 import java.sql.Timestamp;
 
+/**
+ * POJO koji reprezentira jedan red u tabeli OSUMNJICENI_FOTOGRAFIJE — fotografija
+ * (mugshot ili druga slika) priložena uz profil osumnjičenog.
+ *
+ * <p>Veže se na: OSUMNJICENI (kroz OSUMNJICENI_ID), nbp.NBP_USER (kroz
+ * DODAO_USER_ID i IZMIJENIO_USER_ID). Polje {@code fotografija} je BLOB kolona;
+ * preporučena maksimalna veličina fajla je 10 MB (ograničenje na nivou servisa).
+ */
 @Setter
 @Getter
 public class OsumnjiceniFotografija {
-    // Getteri i setteri
+    /** Primarni ključ — kolona FOTOGRAFIJA_ID. */
     private Long fotografijaId;
+
+    /** FK na OSUMNJICENI.OSUMNJICENI_ID — osumnjičeni kome fotografija pripada — kolona OSUMNJICENI_ID. */
     private Long osumnjiceniId;
+
+    /** Binarni sadržaj fotografije (BLOB) — kolona FOTOGRAFIJA. */
     private byte[] fotografija;
+
+    /** Originalni naziv fajla pri uploadu — kolona NAZIV_FAJLA. */
     private String nazivFajla;
+
+    /** MIME tip fajla (npr. "image/jpeg", "image/png") — kolona MIME_TYPE. */
     private String mimeType;
+
+    /** Veličina fajla u bajtovima — kolona VELICINA_FAJLA. */
     private Long velicinaFajla;
+
+    /** Redni broj fotografije unutar skupa fotografija jednog osumnjičenog — kolona REDNI_BROJ. */
     private Integer redniBroj;
+
+    /** Datum i vrijeme dodavanja fotografije — kolona DATUM_DODAVANJA. */
     private Timestamp datumDodavanja;
+
+    /** FK na nbp.NBP_USER.ID — korisnik koji je dodao fotografiju — kolona DODAO_USER_ID. */
     private Long dodaoUserId;
+
+    /** Datum i vrijeme posljednje izmjene fotografije — kolona DATUM_IZMJENE. */
     private Timestamp datumIzmjene;
+
+    /** FK na nbp.NBP_USER.ID — korisnik koji je posljednji izmijenio fotografiju — kolona IZMIJENIO_USER_ID. */
     private Long izmijenioUserId;
+
+    /** Slobodni tekstualni opis sadržaja fotografije — kolona OPIS_FOTOGRAFIJE. */
     private String opisFotografije;
+
+    /** Status fotografije (npr. "Aktivan", "Arhiviran") — kolona STATUS. */
     private String status;
 
     // Konstruktori

--- a/suds/src/main/java/ba/unsa/etf/suds/model/Slucaj.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/Slucaj.java
@@ -5,15 +5,36 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.sql.Timestamp;
 
+/**
+ * POJO koji reprezentira jedan red u tabeli SLUCAJEVI — krivični slučaj
+ * koji vodi inspektor pri određenoj policijskoj stanici.
+ *
+ * <p>Veže se na: STANICE (kroz STANICA_ID), nbp.NBP_USER (kroz VODITELJ_USER_ID),
+ * te je nadređeni entitet za DOKAZI, SVJEDOCI, TIM_NA_SLUCAJU,
+ * SLUCAJ_OSUMNJICENI i SLUCAJ_KRIVICNO_DJELO.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class Slucaj {
+    /** Primarni ključ — kolona SLUCAJ_ID. */
     private Long slucajId;        // SLUCAJ_ID
+
+    /** FK na STANICE.STANICA_ID — stanica koja vodi slučaj — kolona STANICA_ID. */
     private Long stanicaId;       // STANICA_ID
+
+    /** Jedinstveni broj slučaja, npr. "KU-2025-0042" — kolona BROJ_SLUCAJA. */
     private String brojSlucaja;   // BROJ_SLUCAJA
+
+    /** Tekstualni opis slučaja — kolona OPIS. */
     private String opis;          // OPIS
+
+    /** Trenutni status slučaja (npr. "Otvoren", "Zatvoren") — kolona STATUS. */
     private String status;        // STATUS
+
+    /** FK na nbp.NBP_USER.ID — inspektor koji vodi slučaj — kolona VODITELJ_USER_ID. */
     private Long voditeljUserId;  // VODITELJ_USER_ID
+
+    /** Datum i vrijeme kreiranja slučaja — kolona DATUM_KREIRANJA. */
     private Timestamp datumKreiranja; // DATUM_KREIRANJA
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/model/SlucajKrivicnoDjelo.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/SlucajKrivicnoDjelo.java
@@ -4,16 +4,34 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * POJO koji reprezentira jedan red u veznoj tabeli SLUCAJ_KRIVICNO_DJELO —
+ * spaja tabele SLUCAJEVI i KRIVICNA_DJELA u relaciji više-prema-više.
+ *
+ * <p>Polja {@code nazivDjela}, {@code kategorija} i {@code kazneniZakonClan}
+ * nisu kolone ove tabele — popunjavaju se JOIN-om pri čitanju radi prikaza
+ * na frontendu.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class SlucajKrivicnoDjelo {
+    /** Primarni ključ veze — kolona VEZA_ID. */
     private Long vezaId;
+
+    /** FK na SLUCAJEVI.SLUCAJ_ID — kolona SLUCAJ_ID. */
     private Long slucajId;
+
+    /** FK na KRIVICNA_DJELA.DJELO_ID — kolona DJELO_ID. */
     private Long djeloId;
-    
+
     // Za prikaz na frontendu (JOIN podaci)
+    /** Naziv krivičnog djela — popunjava se JOIN-om iz KRIVICNA_DJELA.NAZIV. */
     private String nazivDjela;
+
+    /** Kategorija krivičnog djela — popunjava se JOIN-om iz KRIVICNA_DJELA.KATEGORIJA. */
     private String kategorija;
+
+    /** Član Kaznenog zakona — popunjava se JOIN-om iz KRIVICNA_DJELA.KAZNENI_ZAKON_CLAN. */
     private String kazneniZakonClan;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/model/Stanica.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/Stanica.java
@@ -6,12 +6,26 @@ import lombok.NoArgsConstructor;
 
 import java.sql.Timestamp;
 
+/**
+ * POJO koji reprezentira jedan red u tabeli STANICE — policijska stanica
+ * koja je organizaciona jedinica sistema.
+ *
+ * <p>Veže se na: ADRESE (kroz ADRESA_ID). Nadređeni entitet za SLUCAJEVI,
+ * DOKAZI, LANAC_NADZORA i UPOSLENIK_PROFIL.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class Stanica {
+    /** Primarni ključ — kolona STANICA_ID. */
     private Long stanicaId;       // U bazi: STANICA_ID
+
+    /** Naziv policijske stanice — kolona IME_STANICE. */
     private String imeStanice;    // U bazi: IME_STANICE
+
+    /** FK na ADRESE.ADRESA_ID — adresa stanice — kolona ADRESA_ID. */
     private Long adresaId;        // U bazi: ADRESA_ID
+
+    /** Datum i vrijeme kreiranja zapisa o stanici — kolona DATUM_KREIRANJA. */
     private Timestamp datumKreiranja; // U bazi: DATUM_KREIRANJA
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/model/Svjedok.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/Svjedok.java
@@ -4,15 +4,34 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * POJO koji reprezentira jedan red u tabeli SVJEDOCI — svjedok koji je
+ * vezan za određeni krivični slučaj.
+ *
+ * <p>Veže se na: SLUCAJEVI (kroz SLUCAJ_ID), ADRESE (kroz ADRESA_ID).
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class Svjedok {
+    /** Primarni ključ — kolona SVJEDOK_ID. */
     private Long svjedokId;
+
+    /** FK na SLUCAJEVI.SLUCAJ_ID — slučaj za koji svjedok svjedoči — kolona SLUCAJ_ID. */
     private Long slucajId;
+
+    /** Puno ime i prezime svjedoka — kolona IME_PREZIME. */
     private String imePrezime;
+
+    /** Jedinstveni matični broj građana svjedoka — kolona JMBG. */
     private String jmbg;
+
+    /** FK na ADRESE.ADRESA_ID — adresa stanovanja svjedoka — kolona ADRESA_ID. */
     private Long adresaId;
+
+    /** Kontakt telefon svjedoka — kolona KONTAKT_TELEFON. */
     private String kontaktTelefon;
+
+    /** Slobodna bilješka inspektora o svjedoku — kolona BILJESKA. */
     private String biljeska;
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/model/TimNaSlucaju.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/TimNaSlucaju.java
@@ -6,13 +6,29 @@ import lombok.NoArgsConstructor;
 
 import java.sql.Timestamp;
 
+/**
+ * POJO koji reprezentira jedan red u tabeli TIM_NA_SLUCAJU — dodjela uposlenika
+ * određenoj ulozi na krivičnom slučaju.
+ *
+ * <p>Veže se na: SLUCAJEVI (kroz SLUCAJ_ID), nbp.NBP_USER (kroz USER_ID).
+ * Jedan korisnik može biti dodan na više slučajeva s različitim ulogama.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class TimNaSlucaju {
+    /** Primarni ključ — kolona TIM_NA_SLUCAJU_ID. */
     private Long id;              // TIM_NA_SLUCAJU_ID
+
+    /** FK na SLUCAJEVI.SLUCAJ_ID — slučaj na koji je uposlenik dodan — kolona SLUCAJ_ID. */
     private Long slucajId;        // SLUCAJ_ID
+
+    /** FK na nbp.NBP_USER.ID — uposlenik koji je član tima — kolona USER_ID. */
     private Long userId;          // USER_ID
+
+    /** Uloga uposlenika na ovom konkretnom slučaju — kolona ULOGA_NA_SLUCAJU. */
     private String ulogaNaSlucaju; // ULOGA_NA_SLUCAJU
+
+    /** Datum i vrijeme kada je uposlenik dodan u tim — kolona DATUM_DODAVANJA. */
     private Timestamp datumDodavanja; // DATUM_DODAVANJA
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/model/UposlenikProfil.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/model/UposlenikProfil.java
@@ -4,13 +4,29 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * POJO koji reprezentira jedan red u tabeli UPOSLENIK_PROFIL — prošireni profil
+ * uposlenika koji sadrži podatke specifične za policijsku stanicu.
+ *
+ * <p>Veže se na: nbp.NBP_USER (kroz USER_ID), STANICE (kroz STANICA_ID).
+ * Svaki NBP_USER koji je aktivan uposlenik ima tačno jedan UPOSLENIK_PROFIL.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class UposlenikProfil {
+    /** Primarni ključ — kolona PROFIL_ID. */
     private Long profilId;
+
+    /** FK na nbp.NBP_USER.ID — korisnički nalog uposlenika — kolona USER_ID. */
     private Long userId;
+
+    /** FK na STANICE.STANICA_ID — stanica kojoj uposlenik pripada — kolona STANICA_ID. */
     private Long stanicaId;
+
+    /** Jedinstveni broj policijske značke uposlenika — kolona BROJ_ZNACKE. */
     private String brojZnacke;
+
+    /** Status uposlenika; podrazumijevana vrijednost je "Aktivan" — kolona STATUS. */
     private String status; // Po ERD-u ima default: 'Aktivan'
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/repository/AdresaRepository.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/repository/AdresaRepository.java
@@ -8,15 +8,30 @@ import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Repozitorij za rad sa tabelom ADRESE.
+ *
+ * <p>Koristi čisti JDBC bez ORM-a (pravilo predmeta NBP). Svaka metoda
+ * otvara vlastitu konekciju preko {@link DatabaseManager#getConnection()}
+ * i zatvara je kroz try-with-resources. SQLException-i se wrappaju
+ * u RuntimeException sa engleskom porukom.
+ */
 @Repository
 public class AdresaRepository {
 
     private final DatabaseManager dbManager;
 
+    /** Konstruktorska injekcija {@link DatabaseManager}-a. */
     public AdresaRepository(DatabaseManager dbManager) {
         this.dbManager = dbManager;
     }
 
+    /**
+     * Učitava sve adrese iz tabele ADRESE.
+     *
+     * @return lista svih adresa, prazna lista ako nema redova
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     // 1. Get all addresses (SELECT)
     public List<Adresa> findAll() {
         List<Adresa> adrese = new ArrayList<>();
@@ -35,6 +50,13 @@ public class AdresaRepository {
         return adrese;
     }
 
+    /**
+     * Sprema novu adresu u tabelu ADRESE i vraća je sa generisanim ID-om.
+     *
+     * @param adresa objekat adrese koji se sprema
+     * @return isti objekat sa postavljenim {@code adresaId}
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     // 2. Put new address
     public Adresa save(Adresa adresa) {
         String sql = "INSERT INTO Adrese (ulica_i_broj, grad, postanski_broj, drzava) VALUES (?, ?, ?, ?)";
@@ -61,6 +83,15 @@ public class AdresaRepository {
         }
     }
 
+    /**
+     * Sprema novu adresu koristeći proslijeđenu konekciju (za upotrebu unutar transakcije).
+     * Ne otvara vlastitu konekciju — konekcijom upravlja pozivalac.
+     *
+     * @param conn   aktivna JDBC konekcija kojom upravlja pozivalac
+     * @param adresa objekat adrese koji se sprema
+     * @return generisani ADRESA_ID
+     * @throws SQLException ako dođe do SQL greške (propagira se pozivaocu)
+     */
     public Long saveWithConnection(Connection conn, Adresa adresa) throws SQLException {
         String sql = "INSERT INTO Adrese (ulica_i_broj, grad, postanski_broj, drzava) VALUES (?, ?, ?, ?)";
         try (PreparedStatement stmt = conn.prepareStatement(sql, new String[]{"ADRESA_ID"})) {

--- a/suds/src/main/java/ba/unsa/etf/suds/repository/DokazFotografijaRepository.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/repository/DokazFotografijaRepository.java
@@ -12,15 +12,40 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 
+/**
+ * Repozitorij za rad sa tabelom DOKAZ_FOTOGRAFIJE (fotografije dokaza).
+ *
+ * <p>Koristi čisti JDBC bez ORM-a (pravilo predmeta NBP). Svaka metoda
+ * otvara vlastitu konekciju preko {@link DatabaseManager#getConnection()}
+ * i zatvara je kroz try-with-resources. SQLException-i se wrappaju
+ * u RuntimeException sa engleskom porukom.
+ *
+ * <p>Maksimalan broj fotografija po dokazu (10) osiguran je triggerom u bazi.
+ * Jednom dodana fotografija ostaje trajno — nema UPDATE/DELETE operacija.
+ */
 @Repository
 public class DokazFotografijaRepository {
 
     private final DatabaseManager databaseManager;
 
+    /** Konstruktorska injekcija {@link DatabaseManager}-a. */
     public DokazFotografijaRepository(DatabaseManager databaseManager) {
         this.databaseManager = databaseManager;
     }
 
+    /**
+     * Sprema fotografiju za dati dokaz u tabelu DOKAZ_FOTOGRAFIJE.
+     * Ako {@code redniBroj} nije proslijeđen, automatski se određuje sljedeći slobodni redni broj.
+     *
+     * @param dokazId   ID dokaza (FK na DOKAZI)
+     * @param file      multipart fajl koji sadrži fotografiju
+     * @param redniBroj željeni redni broj fotografije, ili {@code null} za automatski
+     * @param userId    ID korisnika koji dodaje fotografiju
+     * @param opis      tekstualni opis fotografije
+     * @return sačuvani objekat {@link DokazFotografija} sa generisanim ID-om
+     * @throws IOException       ako dođe do greške pri čitanju sadržaja fajla
+     * @throws RuntimeException  ako dođe do SQL greške
+     */
     /**
      * Spremanje fotografije za dokaz
      * Max 10 fotografija po dokazu (osigurano triggerom u bazi)
@@ -64,6 +89,15 @@ public class DokazFotografijaRepository {
         }
     }
 
+    /**
+     * Učitava sve fotografije za dati dokaz iz tabele DOKAZ_FOTOGRAFIJE.
+     * Vrši JOIN sa {@code nbp.NBP_USER} radi dohvatanja imena korisnika koji je dodao fotografiju.
+     * Fotografije su kodirane u Base64 za slanje frontendu.
+     *
+     * @param dokazId ID dokaza čije se fotografije traže
+     * @return lista DTO objekata sa Base64-enkodiranim fotografijama, sortirana po rednom broju
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     /**
      * Dobavljanje svih fotografija za dokaz
      * Vraća DTO sa Base64 enkodiranim slikama za frontend
@@ -125,6 +159,13 @@ public class DokazFotografijaRepository {
         return 1;
     }
 
+    /**
+     * Broji fotografije za dati dokaz u tabeli DOKAZ_FOTOGRAFIJE.
+     *
+     * @param dokazId ID dokaza
+     * @return broj fotografija, ili 0 ako nema nijedne
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     /**
      * Provjera broja fotografija za dokaz
      */

--- a/suds/src/main/java/ba/unsa/etf/suds/repository/DokazRepository.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/repository/DokazRepository.java
@@ -11,16 +11,35 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Repozitorij za rad sa tabelom DOKAZI (forenzički dokazi).
+ *
+ * <p>Koristi čisti JDBC bez ORM-a (pravilo predmeta NBP). Svaka metoda
+ * otvara vlastitu konekciju preko {@link DatabaseManager#getConnection()}
+ * i zatvara je kroz try-with-resources. SQLException-i se wrappaju
+ * u RuntimeException sa engleskom porukom.
+ *
+ * <p>Neke metode vrše JOIN sa tabelama LANAC_NADZORA i {@code nbp.NBP_USER}
+ * radi dohvatanja proširenih informacija o dokazima.
+ */
 @Repository
 public class DokazRepository {
 
     private final DatabaseManager databaseManager;
 
+    /** Konstruktorska injekcija {@link DatabaseManager}-a. */
     // Spring automatski injekta tvoj DatabaseManager
     public DokazRepository(DatabaseManager databaseManager) {
         this.databaseManager = databaseManager;
     }
 
+    /**
+     * Sprema novi dokaz u tabelu DOKAZI i vraća ga sa generisanim ID-om.
+     *
+     * @param dokaz objekat dokaza koji se sprema
+     * @return isti objekat sa postavljenim {@code dokazId}
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public Dokaz save(Dokaz dokaz) {
         String sql = "INSERT INTO Dokazi (slucaj_id, stanica_id, opis, lokacija_pronalaska, tip_dokaza, status, datum_prikupa, prikupio_user_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
 
@@ -47,6 +66,14 @@ public class DokazRepository {
         }
     }
 
+    /**
+     * Učitava listu dokaza za dati slučaj iz tabele DOKAZI.
+     * Vrši LEFT JOIN sa {@code nbp.NBP_USER} radi dohvatanja imena prikupljača.
+     *
+     * @param slucajId ID slučaja čiji se dokazi traže
+     * @return lista DTO objekata, sortirana po datumu prikupljanja silazno
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public List<DokazListDTO> findBySlucajId(Long slucajId) {
         String sql = "SELECT d.DOKAZ_ID, d.OPIS, d.LOKACIJA_PRONALASKA, d.TIP_DOKAZA, d.STATUS, " +
                 "(u.FIRST_NAME||' '||u.LAST_NAME) AS PRIKUPIO_IME, d.DATUM_PRIKUPA, d.SLUCAJ_ID " +
@@ -80,6 +107,15 @@ public class DokazRepository {
         return rezultat;
     }
 
+    /**
+     * Dohvata trenutno stanje dokaza: ko ga drži, status i da li postoji čekajuća potvrda.
+     * Izvršava tri SQL upita unutar iste konekcije: osnovni podaci, zadnja potvrđena primopredaja
+     * i provjera čekajućih potvrda.
+     *
+     * @param dokazId ID dokaza
+     * @return Optional sa {@link DokazStanjeInfo} ako dokaz postoji, inače prazan
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public Optional<DokazStanjeInfo> findStanje(Long dokazId) {
         String dokazSql = "SELECT DOKAZ_ID, STATUS, PRIKUPIO_USER_ID FROM DOKAZI WHERE DOKAZ_ID = ?";
         String confirmedSql = "SELECT PREUZEO_USER_ID, DATUM_PRIMOPREDAJE " +
@@ -149,6 +185,14 @@ public class DokazRepository {
         }
     }
 
+    /**
+     * Učitava kompletan lanac nadzora za dati dokaz sa imenima svih učesnika.
+     * Vrši JOIN sa {@code nbp.NBP_USER} za predavaoca, primaoca i potvrđivača.
+     *
+     * @param dokazId ID dokaza
+     * @return lista DTO objekata lanca nadzora, sortirana po datumu primopredaje uzlazno
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public List<LanacDetaljiDTO> findLanacWithNames(Long dokazId) {
         String sql = "SELECT ln.UNOS_ID, ln.DATUM_PRIMOPREDAJE, " +
                 "(u1.FIRST_NAME||' '||u1.LAST_NAME) AS PREDAO_IME, " +
@@ -187,6 +231,13 @@ public class DokazRepository {
         return lanac;
     }
 
+    /**
+     * Dohvata ID stanice kojoj pripada dati korisnik iz tabele UPOSLENIK_PROFIL.
+     *
+     * @param userId ID korisnika
+     * @return ID stanice, ili {@code null} ako korisnik nema profil ili stanica nije postavljena
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public Long findStanicaIdByUserId(Long userId) {
         String sql = "SELECT STANICA_ID FROM UPOSLENIK_PROFIL WHERE USER_ID = ?";
         try (Connection conn = databaseManager.getConnection();
@@ -204,6 +255,14 @@ public class DokazRepository {
         }
     }
 
+    /**
+     * Ažurira status dokaza u tabeli DOKAZI.
+     *
+     * @param dokazId    ID dokaza koji se ažurira
+     * @param noviStatus novi status koji se postavlja
+     * @return {@code true} ako je ažuriran barem jedan red, inače {@code false}
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public boolean updateStatus(Long dokazId, String noviStatus) {
         String sql = "UPDATE Dokazi SET STATUS = ? WHERE DOKAZ_ID = ?";
         try (Connection conn = databaseManager.getConnection();
@@ -216,6 +275,13 @@ public class DokazRepository {
         }
     }
 
+    /**
+     * Pretražuje dokaz po primarnom ključu u tabeli DOKAZI.
+     *
+     * @param id vrijednost DOKAZ_ID kolone
+     * @return objekat dokaza ako postoji, ili {@code null}
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public Dokaz findById(Long id) {
         String sql = "SELECT * FROM Dokazi WHERE dokaz_id = ?";
 

--- a/suds/src/main/java/ba/unsa/etf/suds/repository/ForenzickiIzvjestajRepository.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/repository/ForenzickiIzvjestajRepository.java
@@ -6,15 +6,31 @@ import org.springframework.stereotype.Repository;
 
 import java.sql.*;
 
+/**
+ * Repozitorij za rad sa tabelom FORENZICKI_IZVJESTAJI (forenzički izvještaji).
+ *
+ * <p>Koristi čisti JDBC bez ORM-a (pravilo predmeta NBP). Svaka metoda
+ * otvara vlastitu konekciju preko {@link DatabaseManager#getConnection()}
+ * i zatvara je kroz try-with-resources. SQLException-i se wrappaju
+ * u RuntimeException sa engleskom porukom.
+ */
 @Repository
 public class ForenzickiIzvjestajRepository {
 
     private final DatabaseManager databaseManager;
 
+    /** Konstruktorska injekcija {@link DatabaseManager}-a. */
     public ForenzickiIzvjestajRepository(DatabaseManager databaseManager) {
         this.databaseManager = databaseManager;
     }
 
+    /**
+     * Dohvata zaključak najnovijeg forenzičkog izvještaja za dati dokaz.
+     *
+     * @param dokazId ID dokaza
+     * @return tekst zaključka, ili {@code null} ako nema izvještaja
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public String findZakljucakByDokazId(Long dokazId) {
         String sql = "SELECT zakljucak FROM Forenzicki_Izvjestaji WHERE dokaz_id = ? ORDER BY datum_kreiranja DESC";
 
@@ -33,6 +49,13 @@ public class ForenzickiIzvjestajRepository {
         }
     }
 
+    /**
+     * Dohvata kompletan forenzički izvještaj za dati dokaz (najnoviji po datumu kreiranja).
+     *
+     * @param dokazId ID dokaza
+     * @return objekat izvještaja ako postoji, ili {@code null}
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public ForenzickiIzvjestaj findByDokazId(Long dokazId) {
         String sql = "SELECT izvjestaj_id, dokaz_id, kreator_user_id, sadrzaj, zakljucak, datum_kreiranja " +
                      "FROM Forenzicki_Izvjestaji WHERE dokaz_id = ? ORDER BY datum_kreiranja DESC";
@@ -61,6 +84,14 @@ public class ForenzickiIzvjestajRepository {
         }
     }
 
+    /**
+     * Sprema novi forenzički izvještaj u tabelu FORENZICKI_IZVJESTAJI.
+     * Automatski postavlja {@code datumKreiranja} na trenutno vrijeme.
+     *
+     * @param izvjestaj objekat izvještaja koji se sprema
+     * @return isti objekat sa postavljenim {@code datumKreiranja}
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public ForenzickiIzvjestaj save(ForenzickiIzvjestaj izvjestaj) {
         String sql = "INSERT INTO Forenzicki_Izvjestaji (dokaz_id, kreator_user_id, sadrzaj, zakljucak, datum_kreiranja) " +
                      "VALUES (?, ?, ?, ?, ?)";
@@ -84,6 +115,13 @@ public class ForenzickiIzvjestajRepository {
         }
     }
 
+    /**
+     * Ažurira sadržaj i zaključak postojećeg forenzičkog izvještaja.
+     *
+     * @param izvjestaj objekat sa postavljenim {@code izvjestajId}, {@code sadrzaj} i {@code zakljucak}
+     * @return isti objekat nakon ažuriranja
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public ForenzickiIzvjestaj update(ForenzickiIzvjestaj izvjestaj) {
     String sql = "UPDATE Forenzicki_Izvjestaji SET sadrzaj = ?, zakljucak = ? WHERE izvjestaj_id = ?";
 

--- a/suds/src/main/java/ba/unsa/etf/suds/repository/IzvjestajRepository.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/repository/IzvjestajRepository.java
@@ -10,15 +10,36 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Repozitorij za generisanje i čuvanje izvještaja slučajeva.
+ *
+ * <p>Upravlja tabelom IZVJESTAJI_SLUCAJEVA i vrši cross-table čitanja iz tabela
+ * SLUCAJEVI, DOKAZI, DOKAZ_FOTOGRAFIJE, LANAC_NADZORA, TIM_NA_SLUCAJU,
+ * SVJEDOCI, OSUMNJICENI, OSUMNJICENI_FOTOGRAFIJE, KRIVICNA_DJELA i
+ * {@code nbp.NBP_USER} radi agregacije podataka za PDF izvještaj.
+ *
+ * <p>Koristi čisti JDBC bez ORM-a (pravilo predmeta NBP). Svaka metoda
+ * otvara vlastitu konekciju preko {@link DatabaseManager#getConnection()}
+ * i zatvara je kroz try-with-resources. SQLException-i se wrappaju
+ * u RuntimeException sa engleskom porukom.
+ */
 @Repository
 public class IzvjestajRepository {
 
     private final DatabaseManager databaseManager;
 
+    /** Konstruktorska injekcija {@link DatabaseManager}-a. */
     public IzvjestajRepository(DatabaseManager databaseManager) {
         this.databaseManager = databaseManager;
     }
 
+    /**
+     * Dohvata osnovne informacije o slučaju za izvještaj (JOIN sa STANICE i {@code nbp.NBP_USER}).
+     *
+     * @param slucajId ID slučaja
+     * @return Optional sa {@link IzvjestajDTO.SlucajInfo} ako slučaj postoji, inače prazan
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public Optional<IzvjestajDTO.SlucajInfo> findSlucajInfo(Long slucajId) {
         String sql = """
             SELECT s.SLUCAJ_ID, s.BROJ_SLUCAJA, s.OPIS, s.STATUS, s.DATUM_KREIRANJA,
@@ -52,6 +73,13 @@ public class IzvjestajRepository {
         return Optional.empty();
     }
 
+    /**
+     * Dohvata sve dokaze za dati slučaj za izvještaj, uključujući fotografije u Base64.
+     *
+     * @param slucajId ID slučaja
+     * @return lista {@link IzvjestajDTO.DokazInfo} objekata, sortirana po datumu prikupljanja
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public List<IzvjestajDTO.DokazInfo> findDokazi(Long slucajId) {
         String sql = """
             SELECT d.DOKAZ_ID, d.OPIS, d.TIP_DOKAZA, d.LOKACIJA_PRONALASKA, 
@@ -115,6 +143,13 @@ public class IzvjestajRepository {
         return base64Slike;
     }
 
+    /**
+     * Dohvata kompletan lanac nadzora za sve dokaze na slučaju za izvještaj.
+     *
+     * @param slucajId ID slučaja
+     * @return lista {@link IzvjestajDTO.LanacNadzoraInfo} objekata, sortirana po datumu primopredaje
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public List<IzvjestajDTO.LanacNadzoraInfo> findLanacNadzora(Long slucajId) {
         String sql = """
             SELECT ln.UNOS_ID, ln.DATUM_PRIMOPREDAJE, ln.SVRHA_PRIMOPREDAJE,
@@ -158,6 +193,13 @@ public class IzvjestajRepository {
         return lanac;
     }
 
+    /**
+     * Dohvata tim dodijeljen na slučaj za izvještaj (JOIN sa {@code nbp.NBP_USER}, {@code nbp.NBP_ROLE} i UPOSLENIK_PROFIL).
+     *
+     * @param slucajId ID slučaja
+     * @return lista {@link IzvjestajDTO.TimInfo} objekata, sortirana po ulozi na slučaju
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public List<IzvjestajDTO.TimInfo> findTim(Long slucajId) {
         String sql = """
             SELECT t.ULOGA_NA_SLUCAJU,
@@ -192,6 +234,13 @@ public class IzvjestajRepository {
         return tim;
     }
 
+    /**
+     * Dohvata sve svjedoke na slučaju za izvještaj (LEFT JOIN sa ADRESE).
+     *
+     * @param slucajId ID slučaja
+     * @return lista {@link IzvjestajDTO.SvjedokInfo} objekata, sortirana po imenu
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public List<IzvjestajDTO.SvjedokInfo> findSvjedoci(Long slucajId) {
         String sql = """
             SELECT sv.IME_PREZIME, sv.JMBG, sv.KONTAKT_TELEFON, sv.BILJESKA,
@@ -223,6 +272,13 @@ public class IzvjestajRepository {
         return svjedoci;
     }
 
+    /**
+     * Dohvata sve osumnjičene na slučaju za izvještaj, uključujući fotografije u Base64.
+     *
+     * @param slucajId ID slučaja
+     * @return lista {@link IzvjestajDTO.OsumnjiceniInfo} objekata, sortirana po imenu
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public List<IzvjestajDTO.OsumnjiceniInfo> findOsumnjiceni(Long slucajId) {
         String sql = """
             SELECT o.OSUMNJICENI_ID, o.IME_PREZIME, o.JMBG, o.DATUM_RODJENJA,
@@ -284,6 +340,13 @@ public class IzvjestajRepository {
         return base64Slike;
     }
 
+    /**
+     * Dohvata sva krivična djela vezana za slučaj za izvještaj (JOIN sa KRIVICNA_DJELA).
+     *
+     * @param slucajId ID slučaja
+     * @return lista {@link IzvjestajDTO.KrivicnoDjeloInfo} objekata, sortirana po nazivu
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public List<IzvjestajDTO.KrivicnoDjeloInfo> findKrivicnaDjela(Long slucajId) {
         String sql = """
             SELECT kd.NAZIV, kd.KATEGORIJA, kd.KAZNENI_ZAKON_CLAN
@@ -312,6 +375,22 @@ public class IzvjestajRepository {
         return djela;
     }
 
+    /**
+     * Sprema ili ažurira PDF izvještaj za dati slučaj u tabeli IZVJESTAJI_SLUCAJEVA.
+     * Ako izvještaj već postoji, ažurira ga; inače kreira novi.
+     *
+     * @param slucajId           ID slučaja
+     * @param stanicaId          ID stanice koja generiše izvještaj
+     * @param userId             ID korisnika koji generiše izvještaj
+     * @param imeGenerisao       ime korisnika koji generiše izvještaj
+     * @param pdfSadrzaj         binarni sadržaj PDF fajla
+     * @param brojDokaza         broj dokaza uključenih u izvještaj
+     * @param brojOsumnjicenih   broj osumnjičenih uključenih u izvještaj
+     * @param brojSvjedoka       broj svjedoka uključenih u izvještaj
+     * @param brojClanovaTima    broj članova tima uključenih u izvještaj
+     * @param brojKrivicnihDjela broj krivičnih djela uključenih u izvještaj
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     /**
      * Spasavanje PDF izvještaja u bazu
      * Ako izvještaj već postoji za ovaj slučaj - ažuriraj ga
@@ -418,6 +497,13 @@ public class IzvjestajRepository {
         }
     }
 
+    /**
+     * Dohvata forenzičke izvještaje za sve dokaze na slučaju za izvještaj.
+     *
+     * @param slucajId ID slučaja
+     * @return lista {@link IzvjestajDTO.ForenzickiIzvjestajInfo} objekata, sortirana po datumu kreiranja
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     /**
      * Dohvatanje forenzičkih izvještaja za sve dokaze na slučaju
      */

--- a/suds/src/main/java/ba/unsa/etf/suds/repository/KrivicnoDjeloRepository.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/repository/KrivicnoDjeloRepository.java
@@ -9,14 +9,26 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Repozitorij za upravljanje krivičnim djelima iz tabele {@code KRIVICNA_DJELA}.
+ * Koristi čisti JDBC pristup — konekcije se dohvataju putem {@link ba.unsa.etf.suds.config.DatabaseManager#getConnection()}
+ * i zatvaraju automatski putem try-with-resources. SQL greške se omotavaju u {@link RuntimeException}.
+ */
 @Repository
 public class KrivicnoDjeloRepository {
     private final DatabaseManager dbManager;
 
+    /** Konstruktorska injekcija {@link DatabaseManager}-a. */
     public KrivicnoDjeloRepository(DatabaseManager dbManager) {
         this.dbManager = dbManager;
     }
 
+    /**
+     * Dohvata sva krivična djela iz tabele {@code KRIVICNA_DJELA}.
+     *
+     * @return lista svih krivičnih djela
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public List<KrivicnoDjelo> findAll() {
         List<KrivicnoDjelo> djela = new ArrayList<>();
         String sql = "SELECT * FROM KRIVICNA_DJELA";
@@ -39,6 +51,13 @@ public class KrivicnoDjeloRepository {
         return djela;
     }
 
+    /**
+     * Dohvata krivično djelo po primarnom ključu.
+     *
+     * @param id identifikator krivičnog djela ({@code DJELO_ID})
+     * @return {@link Optional} sa pronađenim djelom, ili prazan ako ne postoji
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public Optional<KrivicnoDjelo> findById(Long id) {
         // Popravljeno: u bazi se kolona zove DJELO_ID, a ne id
         String sql = "SELECT * FROM KRIVICNA_DJELA WHERE DJELO_ID = ?";
@@ -65,6 +84,14 @@ public class KrivicnoDjeloRepository {
     }
 
 
+/**
+     * Sprema novo krivično djelo u tabelu {@code KRIVICNA_DJELA} i vraća entitet sa generisanim ID-om.
+     * Izvršava se unutar eksplicitne transakcije.
+     *
+     * @param djelo krivično djelo koje se sprema
+     * @return sačuvano krivično djelo sa postavljenim {@code id}-om
+     * @throws RuntimeException ako kreiranje nije uspjelo ili nije dobijen generisani ključ
+     */
 public KrivicnoDjelo save(KrivicnoDjelo djelo) {
     String sql = "INSERT INTO KRIVICNA_DJELA (NAZIV, KATEGORIJA, KAZNENI_ZAKON_CLAN) VALUES (?, ?, ?)";
     
@@ -108,6 +135,13 @@ public KrivicnoDjelo save(KrivicnoDjelo djelo) {
     }
 }
 
+    /**
+     * Ažurira postojeće krivično djelo u tabeli {@code KRIVICNA_DJELA}.
+     *
+     * @param djelo krivično djelo sa ažuriranim podacima (mora imati postavljen {@code id})
+     * @return ažurirano krivično djelo
+     * @throws RuntimeException ako djelo nije pronađeno ili dođe do SQL greške
+     */
     public KrivicnoDjelo update(KrivicnoDjelo djelo) {
         String sql = "UPDATE KRIVICNA_DJELA SET NAZIV = ?, KATEGORIJA = ?, KAZNENI_ZAKON_CLAN = ? WHERE DJELO_ID = ?";
         
@@ -132,6 +166,12 @@ public KrivicnoDjelo save(KrivicnoDjelo djelo) {
         }
     }
 
+    /**
+     * Briše krivično djelo iz tabele {@code KRIVICNA_DJELA} po ID-u.
+     *
+     * @param id identifikator krivičnog djela koje se briše
+     * @throws RuntimeException ako djelo nije pronađeno ili dođe do SQL greške
+     */
     public void deleteById(Long id) {
         String sql = "DELETE FROM KRIVICNA_DJELA WHERE DJELO_ID = ?";
         
@@ -151,6 +191,14 @@ public KrivicnoDjelo save(KrivicnoDjelo djelo) {
         }
 }
 
+/**
+     * Provjerava da li krivično djelo sa datim nazivom i članom kaznenog zakona već postoji u bazi.
+     *
+     * @param naziv naziv krivičnog djela
+     * @param kazneniZakonClan član kaznenog zakona
+     * @return {@code true} ako duplikat postoji, {@code false} inače
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
 /**
  * Provjerava da li krivično djelo sa istim nazivom i članom već postoji
  */

--- a/suds/src/main/java/ba/unsa/etf/suds/repository/LanacNadzoraRepository.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/repository/LanacNadzoraRepository.java
@@ -11,15 +11,28 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Repozitorij za upravljanje lancima nadzora (primopredajama dokaza) iz tabele {@code LANAC_NADZORA}.
+ * Koristi čisti JDBC pristup — konekcije se dohvataju putem {@link ba.unsa.etf.suds.config.DatabaseManager#getConnection()}
+ * i zatvaraju automatski putem try-with-resources. SQL greške se omotavaju u {@link RuntimeException}.
+ */
 @Repository
 public class LanacNadzoraRepository {
 
     private final DatabaseManager databaseManager;
 
+    /** Konstruktorska injekcija {@link DatabaseManager}-a. */
     public LanacNadzoraRepository(DatabaseManager databaseManager) {
         this.databaseManager = databaseManager;
     }
 
+    /**
+     * Sprema novi unos primopredaje u tabelu {@code LANAC_NADZORA} i vraća entitet sa generisanim ID-om.
+     *
+     * @param lanac entitet primopredaje koji se sprema
+     * @return sačuvani entitet sa postavljenim {@code unosId}-om
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public LanacNadzora save(LanacNadzora lanac) {
         String sql = "INSERT INTO Lanac_Nadzora (dokaz_id, stanica_id, datum_primopredaje, predao_user_id, preuzeo_user_id, svrha_primopredaje, potvrda_status) VALUES (?, ?, ?, ?, ?, ?, ?)";
 
@@ -51,6 +64,13 @@ public class LanacNadzoraRepository {
         }
     }
 
+    /**
+     * Dohvata unos primopredaje po primarnom ključu.
+     *
+     * @param unosId identifikator unosa ({@code UNOS_ID})
+     * @return {@link Optional} sa pronađenim unosom, ili prazan ako ne postoji
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public Optional<LanacNadzora> findById(Long unosId) {
         String sql = "SELECT * FROM Lanac_Nadzora WHERE UNOS_ID = ?";
         try (Connection conn = databaseManager.getConnection();
@@ -66,6 +86,13 @@ public class LanacNadzoraRepository {
         return Optional.empty();
     }
 
+    /**
+     * Dohvata sve primopredaje koje čekaju potvrdu od strane datog korisnika.
+     *
+     * @param userId identifikator korisnika koji preuzima dokaz
+     * @return lista primopredaja sa statusom "Čeka potvrdu"
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public List<LanacNadzora> findZahtjeviZaKorisnika(Long userId) {
         List<LanacNadzora> zahtjevi = new ArrayList<>();
         String sql = "SELECT * FROM Lanac_Nadzora WHERE PREUZEO_USER_ID = ? AND POTVRDA_STATUS = 'Čeka potvrdu' " +
@@ -83,6 +110,13 @@ public class LanacNadzoraRepository {
         return zahtjevi;
     }
 
+    /**
+     * Prihvata primopredaju postavljanjem statusa na "Potvrđeno" i bilježenjem datuma i korisnika potvrde.
+     *
+     * @param unosId       identifikator unosa koji se prihvata
+     * @param potvrdioUserId identifikator korisnika koji potvrđuje primopredaju
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public void prihvati(Long unosId, Long potvrdioUserId) {
         String sql = "UPDATE Lanac_Nadzora SET POTVRDA_STATUS = 'Potvrđeno', POTVRDA_DATUM = ?, POTVRDIO_USER_ID = ? " +
                      "WHERE UNOS_ID = ?";
@@ -97,6 +131,13 @@ public class LanacNadzoraRepository {
         }
     }
 
+    /**
+     * Dohvata primopredaje koje čekaju potvrdu od strane datog korisnika, sa JOIN-om na dokaze i korisnike.
+     *
+     * @param userId identifikator korisnika koji preuzima dokaz
+     * @return lista DTO-ova sa detaljima primopredaja na čekanju
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public List<PrimopredajaZaPotvrduDTO> findPrimopredajeZaPotvrdu(Long userId) {
         List<PrimopredajaZaPotvrduDTO> rezultat = new ArrayList<>();
         String sql = "SELECT ln.UNOS_ID, d.OPIS AS DOKAZ_OPIS, d.TIP_DOKAZA, " +
@@ -120,6 +161,13 @@ public class LanacNadzoraRepository {
         return rezultat;
     }
 
+    /**
+     * Dohvata primopredaje koje je dati korisnik poslao, a koje još čekaju potvrdu.
+     *
+     * @param userId identifikator korisnika koji je predao dokaz
+     * @return lista DTO-ova sa detaljima poslatih primopredaja na čekanju
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public List<MojaPrimopredajaDTO> findMojaSlanjaNaPotvrdi(Long userId) {
         List<MojaPrimopredajaDTO> rezultat = new ArrayList<>();
         String sql = "SELECT ln.UNOS_ID, d.OPIS AS DOKAZ_OPIS, d.TIP_DOKAZA, " +
@@ -143,6 +191,15 @@ public class LanacNadzoraRepository {
         return rezultat;
     }
 
+    /**
+     * Ažurira status primopredaje (potvrda ili odbijanje) zajedno sa napomenom, datumom i korisnikom koji je odlučio.
+     *
+     * @param unosId         identifikator unosa koji se ažurira
+     * @param status         novi status (npr. "Potvrđeno" ili "Odbijeno")
+     * @param napomena       napomena uz odluku
+     * @param potvrdioUserId identifikator korisnika koji donosi odluku
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public void potvrdiIliOdbij(Long unosId, String status, String napomena, Long potvrdioUserId) {
         String sql = "UPDATE LANAC_NADZORA SET POTVRDA_STATUS=?, POTVRDA_NAPOMENA=?, POTVRDA_DATUM=?, POTVRDIO_USER_ID=? WHERE UNOS_ID=?";
         try (Connection conn = databaseManager.getConnection();
@@ -158,6 +215,14 @@ public class LanacNadzoraRepository {
         }
     }
 
+    /**
+     * Poništava primopredaju postavljanjem statusa na "Poništeno" uz razlog i korisnika koji poništava.
+     *
+     * @param unosId identifikator unosa koji se poništava
+     * @param razlog razlog poništavanja
+     * @param userId identifikator korisnika koji poništava
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public void ponisti(Long unosId, String razlog, Long userId) {
         String sql = "UPDATE LANAC_NADZORA SET POTVRDA_STATUS='Poništeno', POTVRDA_NAPOMENA=?, POTVRDA_DATUM=?, POTVRDIO_USER_ID=? WHERE UNOS_ID=?";
         try (Connection conn = databaseManager.getConnection();
@@ -172,6 +237,13 @@ public class LanacNadzoraRepository {
         }
     }
 
+    /**
+     * Dohvata sve unose lanca nadzora za dati dokaz, sortirane po datumu primopredaje.
+     *
+     * @param dokazId identifikator dokaza
+     * @return lista unosa lanca nadzora za dati dokaz
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public List<LanacNadzora> findByDokazId(Long dokazId) {
         List<LanacNadzora> lanacList = new ArrayList<>();
         String sql = "SELECT * FROM Lanac_Nadzora WHERE dokaz_id = ? ORDER BY datum_primopredaje ASC";

--- a/suds/src/main/java/ba/unsa/etf/suds/repository/NbpRoleRepository.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/repository/NbpRoleRepository.java
@@ -7,14 +7,30 @@ import org.springframework.stereotype.Repository;
 import java.sql.*;
 import java.util.Optional;
 
+/**
+ * Repozitorij za rad sa tabelom {@code nbp.NBP_ROLE} (uloge korisnika).
+ *
+ * <p>Koristi čisti JDBC bez ORM-a (pravilo predmeta NBP). Svaka metoda
+ * otvara vlastitu konekciju preko {@link DatabaseManager#getConnection()}
+ * i zatvara je kroz try-with-resources. SQLException-i se wrappaju
+ * u RuntimeException sa engleskom porukom.
+ */
 @Repository
 public class NbpRoleRepository {
     private final DatabaseManager dbManager;
 
+    /** Konstruktorska injekcija {@link DatabaseManager}-a. */
     public NbpRoleRepository(DatabaseManager dbManager) {
         this.dbManager = dbManager;
     }
 
+    /**
+     * Pretražuje ulogu po primarnom ključu u tabeli {@code nbp.NBP_ROLE}.
+     *
+     * @param id vrijednost ID kolone
+     * @return Optional sa ulogom ako postoji, inače prazan
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public Optional<NbpRole> findById(Long id) {
         String sql = "SELECT * FROM nbp.NBP_ROLE WHERE ID = ?";
         try (Connection conn = dbManager.getConnection();

--- a/suds/src/main/java/ba/unsa/etf/suds/repository/NbpUserRepository.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/repository/NbpUserRepository.java
@@ -7,14 +7,30 @@ import org.springframework.stereotype.Repository;
 import java.sql.*;
 import java.util.Optional;
 
+/**
+ * Repozitorij za rad sa tabelom {@code nbp.NBP_USER} (korisnički nalozi).
+ *
+ * <p>Koristi čisti JDBC bez ORM-a (pravilo predmeta NBP). Svaka metoda
+ * otvara vlastitu konekciju preko {@link DatabaseManager#getConnection()}
+ * i zatvara je kroz try-with-resources. SQLException-i se wrappaju
+ * u RuntimeException sa engleskom porukom.
+ */
 @Repository
 public class NbpUserRepository {
     private final DatabaseManager dbManager;
 
+    /** Konstruktorska injekcija {@link DatabaseManager}-a. */
     public NbpUserRepository(DatabaseManager dbManager) {
         this.dbManager = dbManager;
     }
 
+    /**
+     * Pretražuje korisnika po korisničkom imenu u tabeli {@code nbp.NBP_USER}.
+     *
+     * @param username vrijednost USERNAME kolone
+     * @return Optional sa korisnikom ako postoji, inače prazan
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public Optional<NbpUser> findByUsername(String username) {
         String sql = "SELECT * FROM nbp.NBP_USER WHERE USERNAME = ?";
         try (Connection conn = dbManager.getConnection();
@@ -31,6 +47,13 @@ public class NbpUserRepository {
         return Optional.empty();
     }
 
+    /**
+     * Pretražuje korisnika po primarnom ključu u tabeli {@code nbp.NBP_USER}.
+     *
+     * @param id vrijednost ID kolone
+     * @return Optional sa korisnikom ako postoji, inače prazan
+     * @throws RuntimeException ako dođe do SQL greške
+     */
     public Optional<NbpUser> findById(Long id) {
         String sql = "SELECT * FROM nbp.NBP_USER WHERE ID = ?";
         try (Connection conn = dbManager.getConnection();

--- a/suds/src/main/java/ba/unsa/etf/suds/repository/OsumnjiceniFotografijaRepository.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/repository/OsumnjiceniFotografijaRepository.java
@@ -12,15 +12,33 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 
+/**
+ * Repozitorij za upravljanje fotografijama osumnjičenih iz tabele {@code OSUMNJICENI_FOTOGRAFIJE}.
+ * Koristi čisti JDBC pristup — konekcije se dohvataju putem {@link ba.unsa.etf.suds.config.DatabaseManager#getConnection()}
+ * i zatvaraju automatski putem try-with-resources. SQL greške se omotavaju u {@link RuntimeException}.
+ */
 @Repository
 public class OsumnjiceniFotografijaRepository {
 
     private final DatabaseManager databaseManager;
 
+    /** Konstruktorska injekcija {@link DatabaseManager}-a. */
     public OsumnjiceniFotografijaRepository(DatabaseManager databaseManager) {
         this.databaseManager = databaseManager;
     }
 
+    /**
+     * Sprema fotografiju osumnjičenog u tabelu {@code OSUMNJICENI_FOTOGRAFIJE}.
+     * Maksimalan broj fotografija po osumnjičenom (3) osiguran je triggerom u bazi.
+     *
+     * @param osumnjiceniId identifikator osumnjičenog
+     * @param file          fajl fotografije koji se sprema
+     * @param redniBroj     redni broj fotografije; ako je {@code null}, automatski se određuje
+     * @param userId        identifikator korisnika koji dodaje fotografiju
+     * @param opis          opis fotografije
+     * @return sačuvana fotografija sa generisanim ID-om
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     /**
      * Spremanje fotografije za osumnjičenog
      * Max 3 fotografije po osumnjičenom (osigurano triggerom u bazi)
@@ -63,6 +81,13 @@ public class OsumnjiceniFotografijaRepository {
         }
     }
 
+    /**
+     * Dohvata sve fotografije za datog osumnjičenog sa JOIN-om na korisnike koji su ih dodali/izmijenili.
+     *
+     * @param osumnjiceniId identifikator osumnjičenog
+     * @return lista DTO-ova sa podacima o fotografijama (uključujući Base64 sadržaj)
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     /**
      * Dobavljanje svih fotografija za osumnjičenog
      */
@@ -113,6 +138,15 @@ public class OsumnjiceniFotografijaRepository {
     }
 
     /**
+     * Ažurira sadržaj i metapodatke fotografije osumnjičenog.
+     *
+     * @param fotografijaId identifikator fotografije koja se ažurira
+     * @param file          novi fajl fotografije
+     * @param userId        identifikator korisnika koji vrši izmjenu
+     * @param opis          novi opis fotografije
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
+    /**
      * Ažuriranje fotografije osumnjičenog (dozvoljeno)
      */
     public void update(Long fotografijaId, MultipartFile file, Long userId, String opis) throws IOException {
@@ -136,6 +170,12 @@ public class OsumnjiceniFotografijaRepository {
         }
     }
 
+    /**
+     * Briše fotografiju osumnjičenog iz tabele {@code OSUMNJICENI_FOTOGRAFIJE} po ID-u.
+     *
+     * @param fotografijaId identifikator fotografije koja se briše
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     /**
      * Brisanje fotografije osumnjičenog (dozvoljeno)
      */
@@ -163,6 +203,13 @@ public class OsumnjiceniFotografijaRepository {
         return 1;
     }
 
+    /**
+     * Broji fotografije za datog osumnjičenog.
+     *
+     * @param osumnjiceniId identifikator osumnjičenog
+     * @return broj fotografija u tabeli {@code OSUMNJICENI_FOTOGRAFIJE} za datog osumnjičenog
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public int countByOsumnjiceniId(Long osumnjiceniId) {
         String sql = "SELECT COUNT(*) FROM OSUMNJICENI_FOTOGRAFIJE WHERE OSUMNJICENI_ID = ?";
         try (Connection conn = databaseManager.getConnection();

--- a/suds/src/main/java/ba/unsa/etf/suds/repository/OsumnjiceniRepository.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/repository/OsumnjiceniRepository.java
@@ -10,14 +10,29 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Repozitorij za upravljanje osumnjičenima iz tabele {@code OSUMNJICENI} i vezne tabele {@code SLUCAJ_OSUMNJICENI}.
+ * Koristi čisti JDBC pristup — konekcije se dohvataju putem {@link ba.unsa.etf.suds.config.DatabaseManager#getConnection()}
+ * i zatvaraju automatski putem try-with-resources. SQL greške se omotavaju u {@link RuntimeException}.
+ */
 @Repository
 public class OsumnjiceniRepository {
     private final DatabaseManager dbManager;
 
+    /** Konstruktorska injekcija {@link DatabaseManager}-a. */
     public OsumnjiceniRepository(DatabaseManager dbManager) {
         this.dbManager = dbManager;
     }
 
+    /**
+     * Sprema novog osumnjičenog koristeći proslijeđenu konekciju (za transakcijsku upotrebu).
+     * Vraća generisani {@code OSUMNJICENI_ID}.
+     *
+     * @param conn        aktivna JDBC konekcija
+     * @param osumnjiceni osumnjičeni koji se sprema
+     * @return generisani primarni ključ novog osumnjičenog
+     * @throws SQLException ako dođe do greške pri izvršavanju SQL upita
+     */
     public Long saveWithConnection(Connection conn, Osumnjiceni osumnjiceni) throws SQLException {
         String sql = "INSERT INTO OSUMNJICENI (IME_PREZIME, JMBG, ADRESA_ID, DATUM_RODJENJA) VALUES (?, ?, ?, ?)";
         try (PreparedStatement stmt = conn.prepareStatement(sql, new String[]{"OSUMNJICENI_ID"})) {
@@ -35,6 +50,14 @@ public class OsumnjiceniRepository {
         }
     }
 
+    /**
+     * Dodaje vezu između slučaja i osumnjičenog u tabelu {@code SLUCAJ_OSUMNJICENI} koristeći proslijeđenu konekciju.
+     *
+     * @param conn          aktivna JDBC konekcija
+     * @param slucajId      identifikator slučaja
+     * @param osumnjiceniId identifikator osumnjičenog
+     * @throws SQLException ako dođe do greške pri izvršavanju SQL upita
+     */
     public void linkToSlucaj(Connection conn, Long slucajId, Long osumnjiceniId) throws SQLException {
         String sql = "INSERT INTO SLUCAJ_OSUMNJICENI (SLUCAJ_ID, OSUMNJICENI_ID) VALUES (?, ?)";
         try (PreparedStatement stmt = conn.prepareStatement(sql)) {
@@ -44,6 +67,12 @@ public class OsumnjiceniRepository {
         }
     }
 
+    /**
+     * Sprema novog osumnjičenog u tabelu {@code OSUMNJICENI}.
+     *
+     * @param osumnjiceni osumnjičeni koji se sprema
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public void save(Osumnjiceni osumnjiceni) {
         String sql = "INSERT INTO OSUMNJICENI (IME_PREZIME, JMBG, ADRESA_ID, DATUM_RODJENJA) VALUES (?, ?, ?, ?)";
         try (Connection conn = dbManager.getConnection();
@@ -58,6 +87,12 @@ public class OsumnjiceniRepository {
         }
     }
 
+    /**
+     * Dohvata sve osumnjičene iz tabele {@code OSUMNJICENI}.
+     *
+     * @return lista svih osumnjičenih
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     // READ ALL
     public List<Osumnjiceni> findAll() {
         List<Osumnjiceni> lista = new ArrayList<>();
@@ -74,6 +109,13 @@ public class OsumnjiceniRepository {
         return lista;
     }
 
+    /**
+     * Dohvata osumnjičenog po primarnom ključu.
+     *
+     * @param id identifikator osumnjičenog ({@code OSUMNJICENI_ID})
+     * @return {@link Optional} sa pronađenim osumnjičenim, ili prazan ako ne postoji
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     // READ BY ID
     public Optional<Osumnjiceni> findById(Long id) {
         String sql = "SELECT * FROM OSUMNJICENI WHERE OSUMNJICENI_ID = ?";
@@ -91,6 +133,12 @@ public class OsumnjiceniRepository {
         return Optional.empty();
     }
 
+    /**
+     * Ažurira podatke osumnjičenog u tabeli {@code OSUMNJICENI}.
+     *
+     * @param osumnjiceni osumnjičeni sa ažuriranim podacima (mora imati postavljen {@code osumnjiceniId})
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     // UPDATE
     public void update(Osumnjiceni osumnjiceni) {
         String sql = "UPDATE OSUMNJICENI SET IME_PREZIME = ?, JMBG = ?, ADRESA_ID = ? WHERE OSUMNJICENI_ID = ?";
@@ -106,6 +154,12 @@ public class OsumnjiceniRepository {
         }
     }
 
+    /**
+     * Briše osumnjičenog iz tabele {@code OSUMNJICENI} po ID-u.
+     *
+     * @param id identifikator osumnjičenog koji se briše
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     // DELETE
     public void delete(Long id) {
         String sql = "DELETE FROM OSUMNJICENI WHERE OSUMNJICENI_ID = ?";
@@ -128,6 +182,13 @@ public class OsumnjiceniRepository {
         );
     }
 
+    /**
+     * Dohvata sve osumnjičene vezane za dati slučaj, sa JOIN-om na adrese.
+     *
+     * @param slucajId identifikator slučaja
+     * @return lista DTO-ova sa podacima o osumnjičenima za dati slučaj
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public List<OsumnjiceniDTO> findBySlucajId(Long slucajId) {
     List<OsumnjiceniDTO> lista = new ArrayList<>();
     String sql = "SELECT o.OSUMNJICENI_ID, o.IME_PREZIME, o.JMBG, o.DATUM_RODJENJA, " +

--- a/suds/src/main/java/ba/unsa/etf/suds/repository/SlucajKrivicnoDjeloRepository.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/repository/SlucajKrivicnoDjeloRepository.java
@@ -8,14 +8,27 @@ import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Repozitorij za upravljanje vezama između slučajeva i krivičnih djela iz tabele {@code SLUCAJ_KRIVICNO_DJELO}.
+ * Koristi čisti JDBC pristup — konekcije se dohvataju putem {@link ba.unsa.etf.suds.config.DatabaseManager#getConnection()}
+ * i zatvaraju automatski putem try-with-resources. SQL greške se omotavaju u {@link RuntimeException}.
+ */
 @Repository
 public class SlucajKrivicnoDjeloRepository {
     private final DatabaseManager dbManager;
 
+    /** Konstruktorska injekcija {@link DatabaseManager}-a. */
     public SlucajKrivicnoDjeloRepository(DatabaseManager dbManager) {
         this.dbManager = dbManager;
     }
 
+    /**
+     * Dohvata sva krivična djela povezana sa datim slučajem, sa JOIN-om na tabelu {@code KRIVICNA_DJELA}.
+     *
+     * @param slucajId identifikator slučaja
+     * @return lista veza slučaj–krivično djelo sa detaljima krivičnog djela
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     /**
      * Dohvata sva krivična djela povezana sa slučajem (sa JOIN-om)
      */
@@ -53,6 +66,15 @@ public class SlucajKrivicnoDjeloRepository {
         return veze;
     }
 
+    /**
+     * Dodaje vezu između slučaja i krivičnog djela u tabelu {@code SLUCAJ_KRIVICNO_DJELO}.
+     * Izvršava se unutar eksplicitne transakcije.
+     *
+     * @param slucajId identifikator slučaja
+     * @param djeloId  identifikator krivičnog djela
+     * @return kreirana veza sa generisanim {@code vezaId}-om
+     * @throws RuntimeException ako dodavanje nije uspjelo ili nije dobijen generisani ključ
+     */
     /**
      * Dodaje vezu između slučaja i krivičnog djela
      */
@@ -99,6 +121,13 @@ public class SlucajKrivicnoDjeloRepository {
     }
 
     /**
+     * Dodaje više krivičnih djela na slučaj odjednom koristeći batch insert unutar transakcije.
+     *
+     * @param slucajId identifikator slučaja
+     * @param djeloIds lista identifikatora krivičnih djela koja se dodaju
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
+    /**
      * Dodaje više krivičnih djela na slučaj odjednom (bulk insert)
      */
     public void dodajViseVeza(Long slucajId, List<Long> djeloIds) {
@@ -128,6 +157,12 @@ public class SlucajKrivicnoDjeloRepository {
     }
 
     /**
+     * Briše vezu između slučaja i krivičnog djela po ID-u veze.
+     *
+     * @param vezaId identifikator veze koja se briše
+     * @throws RuntimeException ako veza nije pronađena ili dođe do SQL greške
+     */
+    /**
      * Briše vezu između slučaja i krivičnog djela
      */
     public void ukloniVezu(Long vezaId) {
@@ -149,6 +184,12 @@ public class SlucajKrivicnoDjeloRepository {
     }
 
     /**
+     * Briše sve veze krivičnih djela za dati slučaj iz tabele {@code SLUCAJ_KRIVICNO_DJELO}.
+     *
+     * @param slucajId identifikator slučaja čije se veze brišu
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
+    /**
      * Briše sve veze za dati slučaj
      */
     public void ukloniSveVezeZaSlucaj(Long slucajId) {
@@ -164,6 +205,14 @@ public class SlucajKrivicnoDjeloRepository {
         }
     }
 
+    /**
+     * Provjerava da li veza između datog slučaja i krivičnog djela već postoji.
+     *
+     * @param slucajId identifikator slučaja
+     * @param djeloId  identifikator krivičnog djela
+     * @return {@code true} ako veza postoji, {@code false} inače
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     /**
      * Provjerava da li veza već postoji
      */

--- a/suds/src/main/java/ba/unsa/etf/suds/repository/SlucajRepository.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/repository/SlucajRepository.java
@@ -12,14 +12,26 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Repozitorij za upravljanje slučajevima iz tabele {@code SLUCAJEVI}.
+ * Koristi čisti JDBC pristup — konekcije se dohvataju putem {@link ba.unsa.etf.suds.config.DatabaseManager#getConnection()}
+ * i zatvaraju automatski putem try-with-resources. SQL greške se omotavaju u {@link RuntimeException}.
+ */
 @Repository
 public class SlucajRepository {
     private final DatabaseManager dbManager;
 
+    /** Konstruktorska injekcija {@link DatabaseManager}-a. */
     public SlucajRepository(DatabaseManager dbManager) {
         this.dbManager = dbManager;
     }
 
+    /**
+     * Sprema novi slučaj u tabelu {@code SLUCAJEVI}.
+     *
+     * @param slucaj slučaj koji se sprema
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     // CREATE
     public void save(Slucaj slucaj) {
         String sql = "INSERT INTO SLUCAJEVI (STANICA_ID, BROJ_SLUCAJA, OPIS, STATUS, VODITELJ_USER_ID, DATUM_KREIRANJA) VALUES (?, ?, ?, ?, ?, ?)";
@@ -37,6 +49,12 @@ public class SlucajRepository {
         }
     }
 
+    /**
+     * Dohvata sve slučajeve iz tabele {@code SLUCAJEVI}.
+     *
+     * @return lista svih slučajeva
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     // READ ALL
     public List<Slucaj> findAll() {
         List<Slucaj> slucajevi = new ArrayList<>();
@@ -53,6 +71,13 @@ public class SlucajRepository {
         return slucajevi;
     }
 
+    /**
+     * Dohvata slučaj prema identifikatoru.
+     *
+     * @param id identifikator slučaja
+     * @return {@link Optional} koji sadrži slučaj, ili prazan ako nije pronađen
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     // READ BY ID
     public Optional<Slucaj> findById(Long id) {
         String sql = "SELECT * FROM SLUCAJEVI WHERE SLUCAJ_ID = ?";
@@ -70,6 +95,12 @@ public class SlucajRepository {
         return Optional.empty();
     }
 
+    /**
+     * Ažurira opis, status i voditelja slučaja u tabeli {@code SLUCAJEVI}.
+     *
+     * @param slucaj slučaj s novim podacima
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     // UPDATE
     public void update(Slucaj slucaj) {
         String sql = "UPDATE SLUCAJEVI SET OPIS = ?, STATUS = ?, VODITELJ_USER_ID = ? WHERE SLUCAJ_ID = ?";
@@ -85,6 +116,12 @@ public class SlucajRepository {
         }
     }
 
+    /**
+     * Briše slučaj iz tabele {@code SLUCAJEVI} prema identifikatoru.
+     *
+     * @param id identifikator slučaja koji se briše
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     // DELETE
     public void delete(Long id) {
         String sql = "DELETE FROM SLUCAJEVI WHERE SLUCAJ_ID = ?";
@@ -97,6 +134,13 @@ public class SlucajRepository {
         }
     }
 
+    /**
+     * Dohvata detalje slučaja kao DTO putem JOIN-a s tabelama osumnjičenih i krivičnih djela.
+     *
+     * @param brojSlucaja broj slučaja koji se traži
+     * @return popunjeni {@link ba.unsa.etf.suds.dto.SlucajDetaljiDTO}
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     // COMPLEX READ FOR DTO
     public SlucajDetaljiDTO findDetaljiByBroj(String brojSlucaja) {
         SlucajDetaljiDTO dto = new SlucajDetaljiDTO();
@@ -136,6 +180,15 @@ public class SlucajRepository {
         return dto;
     }
 
+    /**
+     * Sprema novi slučaj koristeći proslijeđenu konekciju i vraća generirani primarni ključ.
+     * Namijenjen za upotrebu unutar transakcija kojima upravlja pozivatelj.
+     *
+     * @param conn   aktivna SQL konekcija kojom upravlja pozivatelj
+     * @param slucaj slučaj koji se sprema
+     * @return generirani {@code SLUCAJ_ID}
+     * @throws SQLException ako dođe do greške pri izvršavanju SQL upita
+     */
     public Long saveWithConnection(Connection conn, Slucaj slucaj) throws SQLException {
         String sql = "INSERT INTO SLUCAJEVI (STANICA_ID, BROJ_SLUCAJA, OPIS, STATUS, VODITELJ_USER_ID, DATUM_KREIRANJA) " +
                      "VALUES (?, ?, ?, ?, ?, ?)";
@@ -158,6 +211,16 @@ public class SlucajRepository {
         }
     }
 
+    /**
+     * Dohvata filtrirani spisak slučajeva kao DTO ovisno o ulozi korisnika.
+     * Šef stanice vidi sve slučajeve svoje stanice; ostali vide samo slučajeve
+     * na kojima su voditelji ili članovi tima.
+     *
+     * @param userId   identifikator korisnika
+     * @param roleName naziv uloge korisnika
+     * @return lista {@link ba.unsa.etf.suds.dto.SlucajListDTO} objekata
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public List<SlucajListDTO> findAllFiltered(Long userId, String roleName) {
         List<SlucajListDTO> rezultat = new ArrayList<>();
         String sql;
@@ -195,6 +258,13 @@ public class SlucajRepository {
         return rezultat;
     }
 
+    /**
+     * Dohvata slučaj s imenom voditelja kao DTO prema identifikatoru.
+     *
+     * @param id identifikator slučaja
+     * @return {@link Optional} koji sadrži {@link ba.unsa.etf.suds.dto.SlucajListDTO}, ili prazan ako nije pronađen
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public Optional<SlucajListDTO> findByIdWithVoditelj(Long id) {
         String sql = "SELECT s.SLUCAJ_ID, s.BROJ_SLUCAJA, s.OPIS, s.STATUS, s.DATUM_KREIRANJA, " +
                 "(u.FIRST_NAME || ' ' || u.LAST_NAME) AS VODITELJ " +
@@ -217,6 +287,14 @@ public class SlucajRepository {
         return Optional.empty();
     }
 
+    /**
+     * Ažurira status slučaja u tabeli {@code SLUCAJEVI}.
+     *
+     * @param id     identifikator slučaja
+     * @param status novi status
+     * @return {@code true} ako je ažuriran barem jedan red, inače {@code false}
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public boolean updateStatus(Long id, String status) {
         String sql = "UPDATE SLUCAJEVI SET STATUS = ? WHERE SLUCAJ_ID = ?";
 
@@ -230,6 +308,16 @@ public class SlucajRepository {
         }
     }
 
+    /**
+     * Dohvata slučajeve korisnika s ulogom na slučaju kao DTO.
+     * Inspektori i šefovi vide slučajeve na kojima su voditelji ili članovi tima;
+     * ostale uloge vide samo slučajeve na kojima su članovi tima.
+     *
+     * @param userId   identifikator korisnika
+     * @param roleName naziv uloge korisnika
+     * @return lista {@link ba.unsa.etf.suds.dto.MojSlucajDTO} objekata
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public List<MojSlucajDTO> findMojiSlucajevi(Long userId, String roleName) {
         List<MojSlucajDTO> rezultat = new ArrayList<>();
         String sql;

--- a/suds/src/main/java/ba/unsa/etf/suds/repository/StanicaRepository.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/repository/StanicaRepository.java
@@ -10,14 +10,26 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Repozitorij za upravljanje policijskim stanicama iz tabele {@code STANICE}.
+ * Koristi čisti JDBC pristup — konekcije se dohvataju putem {@link ba.unsa.etf.suds.config.DatabaseManager#getConnection()}
+ * i zatvaraju automatski putem try-with-resources. SQL greške se omotavaju u {@link RuntimeException}.
+ */
 @Repository
 public class StanicaRepository {
     private final DatabaseManager dbManager;
 
+    /** Konstruktorska injekcija {@link DatabaseManager}-a. */
     public StanicaRepository(DatabaseManager dbManager) {
         this.dbManager = dbManager;
     }
 
+    /**
+     * Dohvata sve policijske stanice iz tabele {@code STANICE}.
+     *
+     * @return lista svih stanica
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public List<Stanica> findAll() {
         List<Stanica> stanice = new ArrayList<>();
         String sql = "SELECT * FROM STANICE";
@@ -40,6 +52,13 @@ public class StanicaRepository {
         return stanice;
     }
 
+    /**
+     * Dohvata stanicu prema identifikatoru.
+     *
+     * @param id identifikator stanice
+     * @return {@link Optional} koji sadrži stanicu, ili prazan ako nije pronađena
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public Optional<Stanica> findById(Long id) {
         String sql = "SELECT * FROM STANICE WHERE STANICA_ID = ?";
         try (Connection conn = dbManager.getConnection();
@@ -62,6 +81,15 @@ public class StanicaRepository {
         return Optional.empty();
     }
 
+    /**
+     * Atomično registruje novu stanicu zajedno s adresom i šefom stanice u jednoj transakciji.
+     * Kreira redove u tabelama {@code ADRESE}, {@code STANICE}, {@code nbp.NBP_USER} i {@code UPOSLENIK_PROFIL}.
+     * U slučaju greške transakcija se poništava (rollback).
+     *
+     * @param req       zahtjev za registraciju koji sadrži podatke o stanici, adresi i šefu
+     * @param roleIdSef identifikator uloge šefa stanice
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public void registerStanicaITips(RegistrationRequest req, Long roleIdSef) {
     Connection conn = null;
     try {

--- a/suds/src/main/java/ba/unsa/etf/suds/repository/SvjedokRepository.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/repository/SvjedokRepository.java
@@ -9,14 +9,28 @@ import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Repozitorij za upravljanje svjedocima iz tabele {@code SVJEDOCI}.
+ * Koristi čisti JDBC pristup — konekcije se dohvataju putem {@link ba.unsa.etf.suds.config.DatabaseManager#getConnection()}
+ * i zatvaraju automatski putem try-with-resources. SQL greške se omotavaju u {@link RuntimeException}.
+ */
 @Repository
 public class SvjedokRepository {
     private final DatabaseManager dbManager;
 
+    /** Konstruktorska injekcija {@link DatabaseManager}-a. */
     public SvjedokRepository(DatabaseManager dbManager) {
         this.dbManager = dbManager;
     }
 
+    /**
+     * Sprema novog svjedoka koristeći proslijeđenu konekciju.
+     * Namijenjen za upotrebu unutar transakcija kojima upravlja pozivatelj.
+     *
+     * @param conn    aktivna SQL konekcija kojom upravlja pozivatelj
+     * @param svjedok svjedok koji se sprema
+     * @throws SQLException ako dođe do greške pri izvršavanju SQL upita
+     */
     public void saveWithConnection(Connection conn, Svjedok svjedok) throws SQLException {
         String sql = "INSERT INTO Svjedoci (SLUCAJ_ID, IME_PREZIME, JMBG, ADRESA_ID, KONTAKT_TELEFON, BILJESKA) " +
                      "VALUES (?, ?, ?, ?, ?, ?)";
@@ -31,6 +45,12 @@ public class SvjedokRepository {
         }
     }
 
+    /**
+     * Dohvata sve svjedoke iz tabele {@code SVJEDOCI}.
+     *
+     * @return lista svih svjedoka
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public List<Svjedok> findAll() {
         List<Svjedok> svjedoci = new ArrayList<>();
         String sql = "SELECT * FROM Svjedoci";
@@ -56,6 +76,13 @@ public class SvjedokRepository {
         return svjedoci;
     }
 
+    /**
+     * Dohvata svjedoke vezane za određeni slučaj kao DTO s podacima o adresi.
+     *
+     * @param slucajId identifikator slučaja
+     * @return lista {@link ba.unsa.etf.suds.dto.SvjedokDTO} objekata
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public List<SvjedokDTO> findBySlucajId(Long slucajId) {
         List<SvjedokDTO> svjedoci = new ArrayList<>();
         String sql = "SELECT sv.SVJEDOK_ID, sv.IME_PREZIME, sv.KONTAKT_TELEFON, " +
@@ -87,6 +114,18 @@ public class SvjedokRepository {
         return svjedoci;
     }
 
+    /**
+     * Sprema novog svjedoka u tabelu {@code SVJEDOCI} i vraća generirani primarni ključ.
+     *
+     * @param slucajId       identifikator slučaja
+     * @param imePrezime     ime i prezime svjedoka
+     * @param jmbg           JMBG svjedoka
+     * @param adresaId       identifikator adrese svjedoka
+     * @param kontaktTelefon kontakt telefon svjedoka
+     * @param biljeska       dodatna bilješka
+     * @return generirani {@code SVJEDOK_ID}
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public Long save(Long slucajId,
                      String imePrezime,
                      String jmbg,

--- a/suds/src/main/java/ba/unsa/etf/suds/repository/TimNaSlucajuRepository.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/repository/TimNaSlucajuRepository.java
@@ -9,14 +9,28 @@ import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Repozitorij za upravljanje članovima tima na slučaju iz tabele {@code TIM_NA_SLUCAJU}.
+ * Koristi čisti JDBC pristup — konekcije se dohvataju putem {@link ba.unsa.etf.suds.config.DatabaseManager#getConnection()}
+ * i zatvaraju automatski putem try-with-resources. SQL greške se omotavaju u {@link RuntimeException}.
+ */
 @Repository
 public class TimNaSlucajuRepository {
     private final DatabaseManager dbManager;
 
+    /** Konstruktorska injekcija {@link DatabaseManager}-a. */
     public TimNaSlucajuRepository(DatabaseManager dbManager) {
         this.dbManager = dbManager;
     }
 
+    /**
+     * Sprema dodjelu člana tima koristeći proslijeđenu konekciju.
+     * Namijenjen za upotrebu unutar transakcija kojima upravlja pozivatelj.
+     *
+     * @param conn aktivna SQL konekcija kojom upravlja pozivatelj
+     * @param tim  dodjela člana tima koja se sprema
+     * @throws SQLException ako dođe do greške pri izvršavanju SQL upita
+     */
     public void saveWithConnection(Connection conn, TimNaSlucaju tim) throws SQLException {
         String sql = "INSERT INTO TIM_NA_SLUCAJU (SLUCAJ_ID, USER_ID, ULOGA_NA_SLUCAJU) VALUES (?, ?, ?)";
         try (PreparedStatement stmt = conn.prepareStatement(sql)) {
@@ -27,6 +41,13 @@ public class TimNaSlucajuRepository {
         }
     }
 
+    /**
+     * Dohvata sve članove tima za određeni slučaj kao DTO s podacima o korisniku i ulozi.
+     *
+     * @param caseId identifikator slučaja
+     * @return lista {@link ba.unsa.etf.suds.dto.TimClanDTO} objekata
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public List<TimClanDTO> findByCaseId(Long caseId) {
         List<TimClanDTO> clanovi = new ArrayList<>();
         String sql = "SELECT t.DODJELA_ID, t.USER_ID, (u.FIRST_NAME||' '||u.LAST_NAME) AS IME_PREZIME, " +
@@ -61,6 +82,13 @@ public class TimNaSlucajuRepository {
         return clanovi;
     }
 
+    /**
+     * Sprema dodjelu člana tima u tabelu {@code TIM_NA_SLUCAJU} i vraća generirani primarni ključ.
+     *
+     * @param tim dodjela člana tima koja se sprema
+     * @return generirani {@code DODJELA_ID}
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public Long save(TimNaSlucaju tim) {
         String sql = "INSERT INTO TIM_NA_SLUCAJU (SLUCAJ_ID, USER_ID, ULOGA_NA_SLUCAJU) VALUES (?, ?, ?)";
         try (Connection conn = dbManager.getConnection();
@@ -84,6 +112,12 @@ public class TimNaSlucajuRepository {
         }
     }
 
+    /**
+     * Briše dodjelu člana tima iz tabele {@code TIM_NA_SLUCAJU} prema identifikatoru dodjele.
+     *
+     * @param id identifikator dodjele koja se briše
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public void deleteById(Long id) {
         String sql = "DELETE FROM TIM_NA_SLUCAJU WHERE DODJELA_ID=?";
         try (Connection conn = dbManager.getConnection();

--- a/suds/src/main/java/ba/unsa/etf/suds/repository/UposlenikRepository.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/repository/UposlenikRepository.java
@@ -17,13 +17,29 @@ import java.util.ArrayList;
 import java.util.List;
 
 
+/**
+ * Repozitorij za upravljanje uposlenicima i njihovim profilima iz tabela {@code nbp.NBP_USER},
+ * {@code UPOSLENIK_PROFIL} i {@code CRNA_LISTA_TOKENA}.
+ * Koristi čisti JDBC pristup — konekcije se dohvataju putem {@link ba.unsa.etf.suds.config.DatabaseManager#getConnection()}
+ * i zatvaraju automatski putem try-with-resources. SQL greške se omotavaju u {@link RuntimeException}.
+ */
 @Repository
 public class UposlenikRepository {
     private final DatabaseManager dbManager;
 
+    /** Konstruktorska injekcija {@link DatabaseManager}-a. */
     public UposlenikRepository(DatabaseManager dbManager) {
         this.dbManager = dbManager;
     }
+
+    /**
+     * Dohvata podatke za prijavu uposlenika prema e-mail adresi i broju značke.
+     *
+     * @param email  e-mail adresa uposlenika
+     * @param znacka broj značke uposlenika
+     * @return {@link Optional} koji sadrži {@link ba.unsa.etf.suds.dto.UposlenikLoginDTO}, ili prazan ako nije pronađen
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public Optional<UposlenikLoginDTO> findByEmailAndZnacka(String email, String znacka) {
         String sql = """
             SELECT 
@@ -64,6 +80,12 @@ public class UposlenikRepository {
         return Optional.empty();
     }
 
+    /**
+     * Dohvata sve uposlenike iz svih stanica kao DTO.
+     *
+     * @return lista svih {@link ba.unsa.etf.suds.dto.UposlenikDTO} objekata
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public List<UposlenikDTO> findAllUposlenici() {
         List<UposlenikDTO> uposlenici = new ArrayList<>();
         String sql = """
@@ -91,6 +113,13 @@ public class UposlenikRepository {
         }
         return uposlenici;
     }
+    /**
+     * Dohvata sve uposlenike određene stanice kao DTO.
+     *
+     * @param stanicaId identifikator stanice
+     * @return lista {@link ba.unsa.etf.suds.dto.UposlenikDTO} objekata za datu stanicu
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public List<UposlenikDTO> findAllByStanicaId(Long stanicaId) {
         List<UposlenikDTO> uposlenici = new ArrayList<>();
         String sql = """
@@ -121,6 +150,13 @@ public class UposlenikRepository {
         }
         return uposlenici;
     }
+    /**
+     * Dohvata uposlenika prema identifikatoru korisnika kao DTO.
+     *
+     * @param userId identifikator korisnika
+     * @return {@link Optional} koji sadrži {@link ba.unsa.etf.suds.dto.UposlenikDTO}, ili prazan ako nije pronađen
+     * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+     */
     public Optional<UposlenikDTO> findByUserId(Long userId) {
         String sql = """
             SELECT 
@@ -154,6 +190,12 @@ public class UposlenikRepository {
         return Optional.empty();
     }
 
+   /**
+    * Dodaje JWT token u tabelu {@code CRNA_LISTA_TOKENA} radi invalidacije pri odjavi.
+    *
+    * @param token JWT token koji se stavlja na crnu listu
+    * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+    */
    public void dodajUTabeluCrnaLista(String token) {
     String sql = "INSERT INTO CRNA_LISTA_TOKENA (TOKEN, EXPIRES_AT) VALUES (?, CURRENT_TIMESTAMP + 1)"; 
     try (Connection conn = dbManager.getConnection();
@@ -165,6 +207,12 @@ public class UposlenikRepository {
     }
 }
 
+/**
+ * Provjerava da li se JWT token nalazi u tabeli {@code CRNA_LISTA_TOKENA}.
+ *
+ * @param token JWT token koji se provjerava
+ * @return {@code true} ako je token na crnoj listi, inače {@code false}
+ */
 public boolean jeLiTokenUcrnojListi(String token) {
     String sql = "SELECT COUNT(*) FROM CRNA_LISTA_TOKENA WHERE TOKEN = ?";
     try (Connection conn = dbManager.getConnection();
@@ -197,6 +245,16 @@ public boolean jeLiTokenUcrnojListi(String token) {
 
     // ========== HR MODUL  ==========
 
+/**
+ * Atomično kreira novog uposlenika u tabelama {@code nbp.NBP_USER} i {@code UPOSLENIK_PROFIL}
+ * unutar jedne transakcije. U slučaju greške transakcija se poništava (rollback).
+ *
+ * @param request        zahtjev s podacima o novom uposleniku
+ * @param stanicaId      identifikator stanice kojoj uposlenik pripada
+ * @param encodedPassword hashirana lozinka
+ * @return generirani {@code USER_ID} novog uposlenika
+ * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+ */
 public int insertUposlenik(DodajUposlenikaRequest request, Long stanicaId, String encodedPassword) {
     String sqlUser = "INSERT INTO nbp.NBP_USER (FIRST_NAME, LAST_NAME, EMAIL, PASSWORD, USERNAME, PHONE_NUMBER, BIRTH_DATE, ADDRESS_ID, ROLE_ID) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
     String sqlProfil = "INSERT INTO UPOSLENIK_PROFIL (USER_ID, STANICA_ID, BROJ_ZNACKE, STATUS) VALUES (?, ?, ?, 'Aktivan')";
@@ -250,6 +308,13 @@ public int insertUposlenik(DodajUposlenikaRequest request, Long stanicaId, Strin
     }
 }
 
+/**
+ * Ažurira status uposlenika u tabeli {@code UPOSLENIK_PROFIL}.
+ *
+ * @param userId    identifikator korisnika
+ * @param newStatus novi status (npr. {@code "Aktivan"} ili {@code "Neaktivan"})
+ * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+ */
 public void updateStatus(Long userId, String newStatus) {
     String sql = "UPDATE UPOSLENIK_PROFIL SET STATUS = ? WHERE USER_ID = ?";
     try (Connection conn = dbManager.getConnection();
@@ -262,6 +327,13 @@ public void updateStatus(Long userId, String newStatus) {
     }
 }
 
+/**
+ * Broji aktivne šefove stanice za određenu stanicu.
+ *
+ * @param stanicaId identifikator stanice
+ * @return broj aktivnih šefova stanice
+ * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+ */
 public int countActiveSefovaPoStanici(Long stanicaId) {
     String sql = "SELECT COUNT(*) FROM nbp.NBP_USER u JOIN nbp.NBP_ROLE r ON u.ROLE_ID = r.ID JOIN UPOSLENIK_PROFIL p ON u.ID = p.USER_ID WHERE p.STANICA_ID = ? AND p.STATUS = 'Aktivan' AND r.NAME = 'SEF_STANICE'";
     try (Connection conn = dbManager.getConnection();
@@ -276,6 +348,13 @@ public int countActiveSefovaPoStanici(Long stanicaId) {
     }
 }
 
+/**
+ * Provjerava da li postoji korisnik s datom e-mail adresom.
+ *
+ * @param email e-mail adresa koja se provjerava
+ * @return {@code true} ako postoji, inače {@code false}
+ * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+ */
 public boolean existsByEmail(String email) {
     String sql = "SELECT COUNT(*) FROM nbp.NBP_USER WHERE EMAIL = ?";
     try (Connection conn = dbManager.getConnection();
@@ -290,6 +369,13 @@ public boolean existsByEmail(String email) {
     }
 }
 
+/**
+ * Provjerava da li postoji korisnik s datim korisničkim imenom.
+ *
+ * @param username korisničko ime koje se provjerava
+ * @return {@code true} ako postoji, inače {@code false}
+ * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+ */
 public boolean existsByUsername(String username) {
     String sql = "SELECT COUNT(*) FROM nbp.NBP_USER WHERE USERNAME = ?";
     try (Connection conn = dbManager.getConnection();
@@ -304,6 +390,13 @@ public boolean existsByUsername(String username) {
     }
 }
 
+/**
+ * Provjerava da li postoji uposlenik s datim brojem značke.
+ *
+ * @param brojZnacke broj značke koji se provjerava
+ * @return {@code true} ako postoji, inače {@code false}
+ * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+ */
 public boolean existsByBrojZnacke(String brojZnacke) {
     String sql = "SELECT COUNT(*) FROM UPOSLENIK_PROFIL WHERE BROJ_ZNACKE = ?";
     try (Connection conn = dbManager.getConnection();
@@ -318,6 +411,14 @@ public boolean existsByBrojZnacke(String brojZnacke) {
     }
 }
 
+/**
+ * Provjerava da li korisnik pripada određenoj stanici.
+ *
+ * @param userId    identifikator korisnika
+ * @param stanicaId identifikator stanice
+ * @return {@code true} ako korisnik pripada stanici, inače {@code false}
+ * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+ */
 public boolean isUserInStanica(Long userId, Long stanicaId) {
     String sql = "SELECT COUNT(*) FROM UPOSLENIK_PROFIL WHERE USER_ID = ? AND STANICA_ID = ?";
     try (Connection conn = dbManager.getConnection();
@@ -333,6 +434,13 @@ public boolean isUserInStanica(Long userId, Long stanicaId) {
     }
 }
 
+/**
+ * Dohvata naziv uloge korisnika prema identifikatoru.
+ *
+ * @param userId identifikator korisnika
+ * @return naziv uloge, ili {@code null} ako korisnik nije pronađen
+ * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+ */
 public String getUserRoleName(Long userId) {
     String sql = "SELECT r.NAME FROM nbp.NBP_USER u JOIN nbp.NBP_ROLE r ON u.ROLE_ID = r.ID WHERE u.ID = ?";
     try (Connection conn = dbManager.getConnection();
@@ -347,6 +455,13 @@ public String getUserRoleName(Long userId) {
     }
 }
 
+/**
+ * Dohvata profil uposlenika iz tabele {@code UPOSLENIK_PROFIL} prema identifikatoru korisnika.
+ *
+ * @param userId identifikator korisnika
+ * @return {@link Optional} koji sadrži {@link ba.unsa.etf.suds.model.UposlenikProfil}, ili prazan ako nije pronađen
+ * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+ */
 public Optional<UposlenikProfil> findProfilByUserId(Long userId) {
     String sql = "SELECT PROFIL_ID, USER_ID, STANICA_ID, BROJ_ZNACKE, STATUS FROM UPOSLENIK_PROFIL WHERE USER_ID = ?";
     try (Connection conn = dbManager.getConnection();
@@ -369,6 +484,15 @@ public Optional<UposlenikProfil> findProfilByUserId(Long userId) {
     }
 }
 
+/**
+ * Provjerava da li postoji drugi korisnik s datom e-mail adresom (isključujući korisnika s datim ID-om).
+ * Koristi se pri ažuriranju profila radi provjere jedinstvenosti e-maila.
+ *
+ * @param email  e-mail adresa koja se provjerava
+ * @param userId identifikator korisnika koji se isključuje iz provjere
+ * @return {@code true} ako drugi korisnik s tim e-mailom postoji, inače {@code false}
+ * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+ */
 public boolean existsByEmailAndNotUserId(String email, Long userId) {
     String sql = "SELECT COUNT(*) FROM nbp.NBP_USER WHERE EMAIL = ? AND ID != ?";
     try (Connection conn = dbManager.getConnection();
@@ -384,6 +508,15 @@ public boolean existsByEmailAndNotUserId(String email, Long userId) {
     }
 }
 
+/**
+ * Ažurira osnove podatke korisnika (ime, prezime, e-mail) u tabeli {@code nbp.NBP_USER}.
+ *
+ * @param userId  identifikator korisnika
+ * @param ime     novo ime
+ * @param prezime novo prezime
+ * @param email   nova e-mail adresa
+ * @throws RuntimeException ako korisnik nije pronađen ili dođe do greške pri izvršavanju SQL upita
+ */
 public void updateBasicInfo(Long userId, String ime, String prezime, String email) {
     String sql = "UPDATE nbp.NBP_USER SET FIRST_NAME = ?, LAST_NAME = ?, EMAIL = ? WHERE ID = ?";
     
@@ -406,6 +539,13 @@ public void updateBasicInfo(Long userId, String ime, String prezime, String emai
     
 }
 
+/**
+ * Ažurira hashiranu lozinku korisnika u tabeli {@code nbp.NBP_USER}.
+ *
+ * @param userId          identifikator korisnika
+ * @param encodedPassword nova hashirana lozinka
+ * @throws RuntimeException ako dođe do greške pri izvršavanju SQL upita
+ */
 public void updatePassword(Long userId, String encodedPassword) {
     String sql = "UPDATE nbp.NBP_USER SET PASSWORD = ? WHERE ID = ?";
     try (Connection conn = dbManager.getConnection();
@@ -418,6 +558,13 @@ public void updatePassword(Long userId, String encodedPassword) {
     }
 }
 
+/**
+ * Dohvata hashiranu lozinku korisnika prema identifikatoru.
+ *
+ * @param userId identifikator korisnika
+ * @return hashirana lozinka
+ * @throws RuntimeException ako korisnik nije pronađen ili dođe do greške pri izvršavanju SQL upita
+ */
 public String getPasswordByUserId(Long userId) {
     String sql = "SELECT PASSWORD FROM nbp.NBP_USER WHERE ID = ?";
     try (Connection conn = dbManager.getConnection();

--- a/suds/src/main/java/ba/unsa/etf/suds/security/JwtFilter.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/security/JwtFilter.java
@@ -14,17 +14,59 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.Collections;
 
+/**
+ * Spring Security filter koji se izvršava <strong>jednom po zahtjevu</strong>
+ * ({@link OncePerRequestFilter}) i obavlja JWT autentifikaciju.
+ * <p>
+ * Tok obrade svakog zahtjeva:
+ * </p>
+ * <ol>
+ *   <li>Čita {@code Authorization} zaglavlje i provjerava {@code Bearer } prefiks;</li>
+ *   <li>Provjerava je li token na crnoj listi ({@code CRNA_LISTA_TOKENA}) —
+ *       ako jeste, vraća HTTP 401 i prekida lanac filtera;</li>
+ *   <li>Parsira token putem {@link JwtUtil} i izvlači {@code userId} i {@code role_name};</li>
+ *   <li>Ako {@link org.springframework.security.core.context.SecurityContextHolder}
+ *       još nema autentifikaciju, kreira
+ *       {@link org.springframework.security.authentication.UsernamePasswordAuthenticationToken}
+ *       s ulogom u formatu {@code ROLE_<role_name>} i upisuje ga u kontekst;</li>
+ *   <li>Prosljeđuje zahtjev dalje u lancu filtera.</li>
+ * </ol>
+ * <p>
+ * Zahtjevi bez {@code Authorization} zaglavlja prolaze kroz filter bez
+ * postavljanja autentifikacije — Spring Security ih dalje tretira kao anonimne.
+ * </p>
+ */
 @Component
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
     private final UposlenikRepository uposlenikRepository; 
 
+    /**
+     * Kreira filter uz injekciju JWT pomoćne klase i repozitorija za provjeru crne liste.
+     *
+     * @param jwtUtil              pomoćna klasa za parsiranje i validaciju JWT tokena
+     * @param uposlenikRepository  repozitorij koji provjerava tablicu {@code CRNA_LISTA_TOKENA}
+     */
     public JwtFilter(JwtUtil jwtUtil, UposlenikRepository uposlenikRepository) {
         this.jwtUtil = jwtUtil;
         this.uposlenikRepository = uposlenikRepository;
     }
 
+    /**
+     * Glavna logika filtera — izvršava se jednom po HTTP zahtjevu.
+     * <p>
+     * Parsira Bearer token iz {@code Authorization} zaglavlja, provjerava
+     * crnu listu tokena ({@code CRNA_LISTA_TOKENA}), te popunjava
+     * {@link SecurityContextHolder} ako token nije poništen.
+     * </p>
+     *
+     * @param request     dolazni HTTP zahtjev
+     * @param response    odlazni HTTP odgovor
+     * @param filterChain ostatak lanca filtera
+     * @throws ServletException ako dođe do greške u obradi servleta
+     * @throws IOException      ako dođe do I/O greške
+     */
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {

--- a/suds/src/main/java/ba/unsa/etf/suds/security/JwtUtil.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/security/JwtUtil.java
@@ -10,12 +10,39 @@ import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
+/**
+ * Pomoćna klasa za generisanje, parsiranje i validaciju JWT tokena.
+ * <p>
+ * Tokeni se potpisuju algoritmom <strong>HMAC-SHA-256</strong> koristeći tajni
+ * ključ iz konfiguracije ({@code jwt.secret}). Svaki token sadrži sljedeće
+ * claim-ove:
+ * </p>
+ * <ul>
+ *   <li>{@code sub} (subject) — {@code userId.toString()}, identifikator korisnika;</li>
+ *   <li>{@code user_id} — numerički ID korisnika ({@code Long});</li>
+ *   <li>{@code role_name} — naziv uloge (npr. {@code "INSPEKTOR"}, {@code "SEF_STANICE"});</li>
+ *   <li>{@code stanica_id} — ID policijske stanice kojoj korisnik pripada ({@code Long});</li>
+ *   <li>{@code iat} — vrijeme izdavanja tokena (issued-at);</li>
+ *   <li>{@code exp} — vrijeme isteka tokena (expiration), podrazumijevano 24h.</li>
+ * </ul>
+ * <p>
+ * Podrazumijevani rok trajanja je {@code 86400000} ms (24 sata), a tajni ključ
+ * se čita iz {@code jwt.secret} u {@code application.yml} s fallback vrijednošću.
+ * </p>
+ */
 @Component
 public class JwtUtil {
 
     private final SecretKey key;
     private final long expirationMs;
 
+    /**
+     * Inicijalizuje JwtUtil s tajnim ključem i rokom trajanja tokena.
+     *
+     * @param secret       tajni ključ za HMAC-SHA-256 potpisivanje, čita se iz
+     *                     {@code jwt.secret} u {@code application.yml}
+     * @param expirationMs trajanje tokena u milisekundama (podrazumijevano 86400000 = 24h)
+     */
     public JwtUtil(
             @Value("${jwt.secret:suds-default-secret-key-koja-mora-biti-dovoljno-dugacka-256bit}") String secret,
             @Value("${jwt.expiration-ms:86400000}") long expirationMs) {
@@ -24,7 +51,17 @@ public class JwtUtil {
     }
 
     /**
-     * Generisanje JWT tokena sa korisničkim informacijama.
+     * Generiše potpisani JWT token s korisničkim podacima.
+     * <p>
+     * Token sadrži claim-ove: {@code sub} (userId), {@code user_id},
+     * {@code role_name}, {@code stanica_id}, {@code iat} i {@code exp}.
+     * Potpis se vrši HMAC-SHA-256 algoritmom.
+     * </p>
+     *
+     * @param userId    jedinstveni identifikator korisnika
+     * @param roleName  naziv uloge korisnika (npr. {@code "INSPEKTOR"})
+     * @param stanicaId ID policijske stanice kojoj korisnik pripada
+     * @return kompaktni JWT string u formatu {@code header.payload.signature}
      */
     public String generateToken(Long userId, String roleName, Long stanicaId) {
         return Jwts.builder()
@@ -38,6 +75,13 @@ public class JwtUtil {
                 .compact();
     }
 
+    /**
+     * Parsira i verificira JWT token te vraća sve claim-ove.
+     *
+     * @param token JWT string koji se parsira
+     * @return {@link Claims} objekt sa svim claim-ovima iz tokena
+     * @throws io.jsonwebtoken.JwtException ako token nije validan ili je istekao
+     */
     public Claims extractClaims(String token) {
         return Jwts.parser()
                 .verifyWith(key)
@@ -46,22 +90,56 @@ public class JwtUtil {
                 .getPayload();
     }
 
+    /**
+     * Izvlači korisnički ID iz {@code sub} claim-a tokena.
+     *
+     * @param token JWT string
+     * @return korisnički ID kao string
+     */
     public String extractUserId(String token) {
         return extractClaims(token).getSubject();
     }
 
+    /**
+     * Izvlači naziv uloge iz {@code role_name} claim-a tokena.
+     *
+     * @param token JWT string
+     * @return naziv uloge (npr. {@code "INSPEKTOR"})
+     */
     public String extractRole(String token) {
         return extractClaims(token).get("role_name", String.class);
     }
 
+    /**
+     * Izvlači ID stanice iz {@code stanica_id} claim-a tokena.
+     *
+     * @param token JWT string
+     * @return ID policijske stanice
+     */
     public Long extractStanicaId(String token) {
         return extractClaims(token).get("stanica_id", Long.class);
     }
 
+    /**
+     * Provjerava je li token istekao na osnovu {@code exp} claim-a.
+     *
+     * @param token JWT string
+     * @return {@code true} ako je token istekao, {@code false} inače
+     */
     public boolean isTokenExpired(String token) {
         return extractClaims(token).getExpiration().before(new Date());
     }
 
+    /**
+     * Provjerava je li token sintaksno ispravan i nije istekao.
+     * <p>
+     * Za razliku od {@link #isTokenExpired(String)}, ova metoda hvata sve
+     * iznimke parsiranja i vraća {@code false} umjesto da ih propagira.
+     * </p>
+     *
+     * @param token JWT string
+     * @return {@code true} ako je token validan i aktivan, {@code false} inače
+     */
     public boolean isTokenValid(String token) {
         try {
             Claims claims = extractClaims(token);
@@ -70,6 +148,13 @@ public class JwtUtil {
             return false;
         }
     }
+    /**
+     * Validira token provjeravajući da li odgovara zadanom korisniku i nije istekao.
+     *
+     * @param token  JWT string
+     * @param userId očekivani korisnički ID
+     * @return {@code true} ako token pripada korisniku i nije istekao
+     */
     public boolean validateToken(String token, Long userId) {
         final String extractedUserId = extractUserId(token);
         return (extractedUserId.equals(userId.toString()) && !isTokenExpired(token));

--- a/suds/src/main/java/ba/unsa/etf/suds/service/AdresaService.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/service/AdresaService.java
@@ -6,19 +6,42 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+/**
+ * Servis za upravljanje adresama u sistemu.
+ *
+ * <p>Adrese su dijeljeni entitet koji se koristi na više mjesta: stanice,
+ * osumnjičeni, svjedoci i uposlenik profili mogu referencirati isti zapis
+ * u tabeli {@code ADRESE}. Servis orkestrira {@link AdresaRepository}.
+ */
 @Service
 public class AdresaService {
 
     private final AdresaRepository adresaRepository;
 
+    /** Konstruktorska injekcija repozitorija adresa. */
     public AdresaService(AdresaRepository adresaRepository) {
         this.adresaRepository = adresaRepository;
     }
 
+    /**
+     * Vraća listu svih adresa u sistemu.
+     *
+     * @return lista svih {@link Adresa} zapisa iz tabele {@code ADRESE}
+     */
     public List<Adresa> getAllAdrese() {
         return adresaRepository.findAll();
     }
 
+    /**
+     * Kreira novu adresu nakon validacije obaveznih polja.
+     *
+     * <p>Polje {@code ulicaIBroj} je obavezno; ako je {@code null} ili prazno,
+     * baca se {@link IllegalArgumentException}.
+     *
+     * @param adresa objekat adrese koji treba sačuvati
+     * @return sačuvana {@link Adresa} sa dodijeljenim primarnim ključem
+     * @throws IllegalArgumentException ako {@code ulicaIBroj} nije popunjen
+     */
     public Adresa createAdresa(Adresa adresa) {
         // Validation before input
         if (adresa.getUlicaIBroj() == null || adresa.getUlicaIBroj().isEmpty()) {

--- a/suds/src/main/java/ba/unsa/etf/suds/service/AuthService.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/service/AuthService.java
@@ -8,6 +8,14 @@ import ba.unsa.etf.suds.security.JwtUtil;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
+/**
+ * Servis za autentifikaciju i upravljanje JWT tokenima.
+ *
+ * <p>Implementira login (email + broj značke + lozinka), logout (dodavanje
+ * tokena u {@code CRNA_LISTA_TOKENA}) i izradu JWT-a kroz {@link JwtUtil}.
+ * Lozinke se provjeravaju kroz {@link BCryptPasswordEncoder}.
+ * Orkestrira {@link UposlenikRepository}.
+ */
 @Service
 public class AuthService {
 
@@ -15,12 +23,26 @@ public class AuthService {
     private final BCryptPasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
 
+    /** Konstruktorska injekcija svih ovisnosti. */
     public AuthService(UposlenikRepository uposlenikRepository, BCryptPasswordEncoder passwordEncoder, JwtUtil jwtUtil) {
         this.uposlenikRepository = uposlenikRepository;
         this.passwordEncoder = passwordEncoder;
         this.jwtUtil = jwtUtil;
     }
 
+    /**
+     * Prijavljuje uposlenika i vraća potpisani JWT token.
+     *
+     * <p>Identitet se utvrđuje kombinacijom (email, brojZnacke); lozinka se
+     * provjerava BCrypt-om. Ako je {@code UPOSLENIK_PROFIL.STATUS} postavljen
+     * na {@code 'Penzionisan'} ili {@code 'Otpušten'}, baca se
+     * {@link RuntimeException} s porukom "Pristup odbijen".
+     *
+     * @param request DTO sa email-om, lozinkom i brojem značke
+     * @return DTO sa potpisanim JWT tokenom (validan po default-u 24h)
+     * @throws RuntimeException ako korisnik nije pronađen, lozinka nije ispravna
+     *                          ili je nalog deaktiviran (Penzionisan/Otpušten)
+     */
     public LoginResponse login(LoginRequest request) {
     UposlenikLoginDTO uposlenik = uposlenikRepository.findByEmailAndZnacka(request.getEmail(), request.getBrojZnacke())
             .orElseThrow(() -> new RuntimeException("Nevalidni podaci: Korisnik nije pronađen!"));
@@ -42,6 +64,17 @@ public class AuthService {
     return new LoginResponse(token, "Bearer");
 }
 
+    /**
+     * Odjavljuje uposlenika dodavanjem JWT tokena u crnu listu.
+     *
+     * <p>Ako zaglavlje {@code Authorization} sadrži prefiks {@code Bearer },
+     * token se ekstrahuje i upisuje u tabelu {@code CRNA_LISTA_TOKENA} putem
+     * {@link UposlenikRepository#dodajUTabeluCrnaLista(String)}.
+     * Naredni zahtjevi s tim tokenom bit će odbijeni od strane JWT filtera.
+     *
+     * @param authHeader vrijednost HTTP zaglavlja {@code Authorization}
+     *                   (npr. {@code "Bearer eyJhbGci..."})
+     */
     public void logout(String authHeader) {
     if (authHeader != null && authHeader.startsWith("Bearer ")) {
         String token = authHeader.substring(7);

--- a/suds/src/main/java/ba/unsa/etf/suds/service/DokazFotografijaService.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/service/DokazFotografijaService.java
@@ -8,25 +8,60 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * Servis za upravljanje fotografijama dokaza.
+ *
+ * <p>Fotografije dokaza su INSERT-only (bez izmjene i brisanja) kako bi se
+ * očuvao integritet lanca nadzora — svaka fotografija je nepromjenjivi
+ * digitalni trag vezan za dokaz. Servis orkestrira
+ * {@link DokazFotografijaRepository}.
+ *
+ * <p>Ograničenja:
+ * <ul>
+ *   <li>Maksimalno <b>10 fotografija</b> po dokazu.</li>
+ *   <li>Maksimalna veličina fajla: <b>10 MB</b>.</li>
+ *   <li>Dozvoljeni tipovi: JPEG, PNG, GIF, WebP.</li>
+ * </ul>
+ */
 @Service
 public class DokazFotografijaService {
 
     private final DokazFotografijaRepository dokazFotografijaRepository;
 
+    /** Konstruktorska injekcija repozitorija fotografija dokaza. */
     public DokazFotografijaService(DokazFotografijaRepository dokazFotografijaRepository) {
         this.dokazFotografijaRepository = dokazFotografijaRepository;
     }
 
     /**
-     * Dobavljanje svih fotografija za dokaz
+     * Dobavlja sve fotografije za zadani dokaz.
+     *
+     * @param dokazId identifikator dokaza
+     * @return lista {@link DokazFotografijaDTO} objekata za dati dokaz
      */
     public List<DokazFotografijaDTO> getFotografijeByDokazId(Long dokazId) {
         return dokazFotografijaRepository.findByDokazId(dokazId);
     }
 
     /**
-     * Upload fotografije za dokaz
-     * @throws RuntimeException ako je dostignut maksimum od 10 fotografija
+     * Uploaduje novu fotografiju za zadani dokaz.
+     *
+     * <p>Primjenjuje sljedeća poslovna pravila:
+     * <ul>
+     *   <li>Maksimalno 10 fotografija po dokazu — baca {@link RuntimeException} ako je limit dostignut.</li>
+     *   <li>Maksimalna veličina fajla je 10 MB.</li>
+     *   <li>Dozvoljeni MIME tipovi: {@code image/jpeg}, {@code image/png}, {@code image/gif}, {@code image/webp}.</li>
+     *   <li>Ako {@code redniBroj} nije proslijeđen, automatski se dodjeljuje sljedeći slobodni redni broj.</li>
+     * </ul>
+     *
+     * @param dokazId   identifikator dokaza
+     * @param file      multipart fajl koji se uploaduje
+     * @param redniBroj željeni redni broj fotografije (1–10); ako je {@code null}, automatski se određuje
+     * @param userId    identifikator uposlenika koji uploaduje fotografiju
+     * @param opis      tekstualni opis fotografije (može biti {@code null})
+     * @throws RuntimeException ako je dostignut maksimum od 10 fotografija, fajl je prevelik
+     *                          ili je tip fajla nedozvoljen
+     * @throws IOException      ako dođe do greške pri čitanju sadržaja fajla
      */
     public void uploadFotografiju(Long dokazId, MultipartFile file, Integer redniBroj,
                                   Long userId, String opis) throws IOException {
@@ -65,14 +100,20 @@ public class DokazFotografijaService {
     }
 
     /**
-     * Provjera da li dokaz ima maksimalan broj fotografija
+     * Provjerava da li je dostignut maksimalni broj fotografija (10) za zadani dokaz.
+     *
+     * @param dokazId identifikator dokaza
+     * @return {@code true} ako dokaz već ima 10 fotografija, inače {@code false}
      */
     public boolean isMaxFotografijaDostignut(Long dokazId) {
         return dokazFotografijaRepository.countByDokazId(dokazId) >= 10;
     }
 
     /**
-     * Broj preostalih mjesta za fotografije
+     * Vraća broj preostalih slobodnih mjesta za fotografije dokaza.
+     *
+     * @param dokazId identifikator dokaza
+     * @return broj preostalih mjesta (0–10)
      */
     public int getPreostaloMjesta(Long dokazId) {
         return 10 - dokazFotografijaRepository.countByDokazId(dokazId);

--- a/suds/src/main/java/ba/unsa/etf/suds/service/DokazService.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/service/DokazService.java
@@ -15,6 +15,14 @@ import org.springframework.stereotype.Service;
 import java.sql.Timestamp;
 import java.util.List;
 
+/**
+ * Servis za upravljanje dokazima i njihovim stanjem u lancu nadzora.
+ *
+ * <p>Orkestrira {@link DokazRepository}, {@link LanacNadzoraRepository} i
+ * {@link ForenzickiIzvjestajRepository}. Odgovoran je za kreiranje dokaza,
+ * praćenje trenutnog nosioca (chain-of-custody), ažuriranje statusa i
+ * sklapanje kompletnog dosijea dokaza.
+ */
 @Service
 public class DokazService {
 
@@ -22,6 +30,7 @@ public class DokazService {
     private final LanacNadzoraRepository lanacNadzoraRepository;
     private final ForenzickiIzvjestajRepository izvjestajRepository;
 
+    /** Konstruktorska injekcija svih ovisnosti. */
     // Spring automatski injekta repozitorije
     public DokazService(DokazRepository dokazRepository,
                         LanacNadzoraRepository lanacNadzoraRepository,
@@ -31,6 +40,15 @@ public class DokazService {
         this.izvjestajRepository = izvjestajRepository;
     }
 
+    /**
+     * Kreira novi dokaz vezan za slučaj.
+     *
+     * <p>Ako {@code datumPrikupa} nije proslijeđen, automatski se postavlja
+     * na trenutno sistemsko vrijeme.
+     *
+     * @param dokaz objekat dokaza koji treba sačuvati
+     * @return sačuvani {@link Dokaz} sa dodijeljenim primarnim ključem
+     */
     // Unos novog dokaza
     public Dokaz kreirajDokaz(Dokaz dokaz) {
         // Ako datum prikupa nije poslan, postavi na trenutno vrijeme
@@ -40,6 +58,16 @@ public class DokazService {
         return dokazRepository.save(dokaz);
     }
 
+    /**
+     * Dodaje novi korak u lanac nadzora za zadani dokaz.
+     *
+     * <p>ID dokaza iz URL putanje se uvijek upisuje u objekat {@code lanac}
+     * kako bi se spriječilo nenamjerno vezivanje za pogrešan dokaz.
+     *
+     * @param dokazId identifikator dokaza
+     * @param lanac   objekat primopredaje koji treba sačuvati
+     * @return sačuvani {@link LanacNadzora} zapis
+     */
     // Dodavanje novog koraka u lanac nadzora
     public LanacNadzora dodajULanacNadzora(Long dokazId, LanacNadzora lanac) {
         // Obavezno uvezujemo proslijeđeni ID dokaza iz URL-a sa objektom
@@ -47,6 +75,13 @@ public class DokazService {
         return lanacNadzoraRepository.save(lanac);
     }
 
+    /**
+     * Sklapa kompletan dosije dokaza: sam dokaz, lanac nadzora i forenzički zaključak.
+     *
+     * @param dokazId identifikator dokaza
+     * @return {@link DokazDosijeDTO} sa svim podacima vezanim za dokaz
+     * @throws IllegalArgumentException ako dokaz sa zadanim ID-em ne postoji
+     */
     // Sklapanje DTO objekta (traženo u zadatku)
     public DokazDosijeDTO getDokazDosije(Long dokazId) {
         Dokaz dokaz = dokazRepository.findById(dokazId);
@@ -62,10 +97,29 @@ public class DokazService {
         return dosije;
     }
 
+    /**
+     * Vraća listu dokaza za zadani slučaj.
+     *
+     * @param slucajId identifikator slučaja
+     * @return lista {@link DokazListDTO} objekata za dati slučaj
+     */
     public List<DokazListDTO> getBySlucajId(Long slucajId) {
         return dokazRepository.findBySlucajId(slucajId);
     }
 
+    /**
+     * Kreira novi dokaz za zadani slučaj i automatski određuje stanicu na osnovu uposlenika.
+     *
+     * <p>Status novog dokaza se postavlja na {@code 'Odobren'}, a datum prikupa
+     * na trenutno sistemsko vrijeme. Stanica se određuje iz profila uposlenika
+     * koji kreira dokaz.
+     *
+     * @param slucajId identifikator slučaja
+     * @param request  DTO sa opisom, lokacijom pronalaska i tipom dokaza
+     * @param userId   identifikator uposlenika koji kreira dokaz
+     * @return {@link DokazListDTO} novokreiranog dokaza
+     * @throws IllegalArgumentException ako uposlenik nema profil ili stanica nije pronađena
+     */
     public DokazListDTO kreirajZaSlucaj(Long slucajId, KreirajDokazRequest request, Long userId) {
         Long stanicaId = dokazRepository.findStanicaIdByUserId(userId);
         if (stanicaId == null) {
@@ -100,6 +154,17 @@ public class DokazService {
                 });
     }
 
+    /**
+     * Vraća trenutno stanje dokaza: ko ga drži i da li može biti proslijeđen.
+     *
+     * <p>Polje {@code mozePredati} je {@code true} samo ako nema čekajuće
+     * potvrde i trenutni nosilac je upravo prijavljeni korisnik ({@code userId}).
+     *
+     * @param dokazId identifikator dokaza
+     * @param userId  identifikator prijavljenog korisnika
+     * @return {@link DokazStanjeDTO} sa informacijom o trenutnom nosiocu i mogućnosti predaje
+     * @throws IllegalArgumentException ako dokaz sa zadanim ID-em ne postoji
+     */
     public DokazStanjeDTO getStanje(Long dokazId, Long userId) {
         DokazRepository.DokazStanjeInfo stanje = dokazRepository.findStanje(dokazId)
                 .orElseThrow(() -> new IllegalArgumentException("Dokaz sa ID-em " + dokazId + " nije pronađen!"));
@@ -119,10 +184,23 @@ public class DokazService {
         return dto;
     }
 
+    /**
+     * Vraća detalje lanca nadzora za dokaz, uključujući imena pošiljaoca i primaoca.
+     *
+     * @param dokazId identifikator dokaza
+     * @return lista {@link LanacDetaljiDTO} sa imenima učesnika primopredaje
+     */
     public List<LanacDetaljiDTO> getLanacWithNames(Long dokazId) {
         return dokazRepository.findLanacWithNames(dokazId);
     }
 
+    /**
+     * Ažurira status dokaza.
+     *
+     * @param dokazId identifikator dokaza
+     * @param status  novi status dokaza (npr. {@code 'Odobren'}, {@code 'Na analizi'})
+     * @throws IllegalArgumentException ako dokaz sa zadanim ID-em ne postoji
+     */
     public void azurirajStatus(Long dokazId, String status) {
         boolean updated = dokazRepository.updateStatus(dokazId, status);
         if (!updated) {

--- a/suds/src/main/java/ba/unsa/etf/suds/service/ForenzickiIzvjestajService.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/service/ForenzickiIzvjestajService.java
@@ -5,14 +5,34 @@ import ba.unsa.etf.suds.repository.ForenzickiIzvjestajRepository;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+/**
+ * Servis za upravljanje forenzičkim izvještajima.
+ *
+ * <p>Kreiranje i izmjena izvještaja dozvoljena je isključivo korisnicima s ulogom
+ * {@code FORENZIČAR} — ovo se provjerava na nivou kontrolera putem
+ * {@code @PreAuthorize}. Servis automatski upisuje ID kreatora iz
+ * {@link org.springframework.security.core.context.SecurityContext}-a.
+ * Orkestrira {@link ForenzickiIzvjestajRepository}.
+ */
 @Service
 public class ForenzickiIzvjestajService {
     private final ForenzickiIzvjestajRepository repository;
 
+    /** Konstruktorska injekcija repozitorija forenzičkih izvještaja. */
     public ForenzickiIzvjestajService(ForenzickiIzvjestajRepository repository) {
         this.repository = repository;
     }
 
+    /**
+     * Kreira novi forenzički izvještaj i automatski upisuje ID kreatora.
+     *
+     * <p>ID kreatora se čita iz {@link org.springframework.security.core.context.SecurityContextHolder}
+     * i upisuje u polje {@code kreatorUserId}. Pristup ovoj metodi je zaštićen
+     * na nivou kontrolera ({@code @PreAuthorize("hasRole('FORENZIČAR')")}).
+     *
+     * @param izvjestaj objekat izvještaja koji treba sačuvati
+     * @return sačuvani {@link ForenzickiIzvjestaj} sa dodijeljenim primarnim ključem
+     */
     public ForenzickiIzvjestaj kreirajIzvjestaj(ForenzickiIzvjestaj izvjestaj) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         izvjestaj.setKreatorUserId(Long.parseLong(principal.toString()));
@@ -20,10 +40,25 @@ public class ForenzickiIzvjestajService {
         return repository.save(izvjestaj);
     }
 
+    /**
+     * Vraća forenzički izvještaj vezan za zadani dokaz.
+     *
+     * @param dokazId identifikator dokaza
+     * @return {@link ForenzickiIzvjestaj} za dati dokaz, ili {@code null} ako ne postoji
+     */
     public ForenzickiIzvjestaj getIzvjestajZaDokaz(Long dokazId) {
         return repository.findByDokazId(dokazId);
     }
 
+    /**
+     * Ažurira postojeći forenzički izvještaj.
+     *
+     * <p>Pristup ovoj metodi je zaštićen na nivou kontrolera
+     * ({@code @PreAuthorize("hasRole('FORENZIČAR')")}).
+     *
+     * @param izvjestaj objekat izvještaja sa ažuriranim podacima (mora imati postavljen ID)
+     * @return ažurirani {@link ForenzickiIzvjestaj}
+     */
     public ForenzickiIzvjestaj azurirajIzvjestaj(ForenzickiIzvjestaj izvjestaj) {
     return repository.update(izvjestaj);
 }

--- a/suds/src/main/java/ba/unsa/etf/suds/service/KrivicnoDjeloService.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/service/KrivicnoDjeloService.java
@@ -5,24 +5,57 @@ import ba.unsa.etf.suds.repository.KrivicnoDjeloRepository;
 import org.springframework.stereotype.Service;
 import java.util.List;
 
+/**
+ * Servis za upravljanje katalogom krivičnih djela.
+ *
+ * <p>Krivična djela su globalni katalog koji se koristi za označavanje slučajeva.
+ * Jedinstvenost se provjerava na kombinaciji {@code UPPER(NAZIV)} i
+ * {@code UPPER(KAZNENI_ZAKON_CLAN)} kako bi se spriječili duplikati bez obzira
+ * na velika/mala slova. Orkestrira {@link KrivicnoDjeloRepository}.
+ */
 @Service
 public class KrivicnoDjeloService {
     private final KrivicnoDjeloRepository repository;
 
+    /** Konstruktorska injekcija repozitorija krivičnih djela. */
     public KrivicnoDjeloService(KrivicnoDjeloRepository repository) {
         this.repository = repository;
     }
 
+    /**
+     * Vraća listu svih krivičnih djela iz kataloga.
+     *
+     * @return lista svih {@link KrivicnoDjelo} zapisa
+     */
     public List<KrivicnoDjelo> getAll() {
         return repository.findAll();
     }
 
+    /**
+     * Vraća krivično djelo po ID-u.
+     *
+     * @param id identifikator krivičnog djela
+     * @return pronađeni {@link KrivicnoDjelo}
+     * @throws RuntimeException ako krivično djelo sa zadanim ID-em ne postoji
+     */
     public KrivicnoDjelo getById(Long id) {
         return repository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Krivično djelo nije pronađeno!"));
     }
 
 
+    /**
+     * Kreira novo krivično djelo u katalogu.
+     *
+     * <p>Provjerava jedinstvenost kombinacije {@code (naziv, kazneniZakonClan)}
+     * bez obzira na velika/mala slova ({@code UPPER} poređenje u bazi).
+     * Oba polja su obavezna.
+     *
+     * @param djelo objekat krivičnog djela koji treba sačuvati
+     * @return sačuvani {@link KrivicnoDjelo} sa dodijeljenim primarnim ključem
+     * @throws IllegalArgumentException ako {@code naziv} ili {@code kazneniZakonClan} nisu popunjeni
+     * @throws IllegalArgumentException ako kombinacija (naziv, član) već postoji u katalogu
+     */
     public KrivicnoDjelo create(KrivicnoDjelo djelo) {
         // Validacije
         if (djelo.getNaziv() == null || djelo.getNaziv().trim().isEmpty()) {
@@ -39,6 +72,18 @@ public class KrivicnoDjeloService {
         return repository.save(djelo);
     }
 
+    /**
+     * Ažurira postojeće krivično djelo u katalogu.
+     *
+     * <p>Provjerava da li krivično djelo postoji prije ažuriranja.
+     * Oba polja ({@code naziv} i {@code kazneniZakonClan}) su obavezna.
+     *
+     * @param id    identifikator krivičnog djela koje se ažurira
+     * @param djelo objekat sa novim podacima
+     * @return ažurirani {@link KrivicnoDjelo}
+     * @throws RuntimeException         ako krivično djelo sa zadanim ID-em ne postoji
+     * @throws IllegalArgumentException ako {@code naziv} ili {@code kazneniZakonClan} nisu popunjeni
+     */
     public KrivicnoDjelo update(Long id, KrivicnoDjelo djelo) {
         // Provjeri da li postoji
         repository.findById(id)
@@ -57,6 +102,12 @@ public class KrivicnoDjeloService {
         return repository.update(djelo);
     }
 
+    /**
+     * Briše krivično djelo iz kataloga.
+     *
+     * @param id identifikator krivičnog djela koje se briše
+     * @throws RuntimeException ako krivično djelo sa zadanim ID-em ne postoji
+     */
     public void delete(Long id) {
         // Provjeri da li postoji
         repository.findById(id)

--- a/suds/src/main/java/ba/unsa/etf/suds/service/LanacNadzoraService.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/service/LanacNadzoraService.java
@@ -14,16 +14,42 @@ import org.springframework.stereotype.Service;
 import java.sql.Timestamp;
 import java.util.List;
 
+/**
+ * Servis za upravljanje lancem nadzora (chain of custody) dokaza.
+ *
+ * <p>Implementira mašinu stanja primopredaje dokaza:
+ * <ol>
+ *   <li>{@code posaljiDokaz} / {@code kreirajPrimopredaju} — kreira novi unos sa statusom
+ *       {@code 'Čeka potvrdu'}.</li>
+ *   <li>{@code potvrdiIliOdbij} — primaoc postavlja status na {@code 'Potvrđeno'} ili
+ *       {@code 'Odbijeno'}; samo primaoc može izvršiti ovu akciju.</li>
+ *   <li>{@code ponistiPrimopredaju} — pošiljalac može poništiti primopredaju dok je u
+ *       statusu {@code 'Čeka potvrdu'}.</li>
+ * </ol>
+ *
+ * <p>Orkestrira {@link LanacNadzoraRepository} i {@link DokazRepository}.
+ */
 @Service
 public class LanacNadzoraService {
     private final LanacNadzoraRepository lanacRepository;
     private final DokazRepository dokazRepository;
 
+    /** Konstruktorska injekcija svih ovisnosti. */
     public LanacNadzoraService(LanacNadzoraRepository lanacRepository, DokazRepository dokazRepository) {
         this.lanacRepository = lanacRepository;
         this.dokazRepository = dokazRepository;
     }
 
+    /**
+     * Inicira primopredaju dokaza kreiranjem novog unosa u lancu nadzora.
+     *
+     * <p>Novi unos dobiva status {@code 'Čeka potvrdu'}. Datum primopredaje
+     * se automatski postavlja na trenutno sistemsko vrijeme.
+     *
+     * @param request      DTO sa ID-em dokaza, stanice, primaoca i svrhom primopredaje
+     * @param predaoUserId identifikator uposlenika koji šalje dokaz
+     * @return sačuvani {@link LanacNadzora} zapis
+     */
     public LanacNadzora posaljiDokaz(PosaljiDokazRequest request, Long predaoUserId) {
         LanacNadzora lanac = new LanacNadzora();
         lanac.setDokazId(request.getDokazId());
@@ -37,10 +63,27 @@ public class LanacNadzoraService {
         return lanacRepository.save(lanac);
     }
 
+    /**
+     * Vraća sve zahtjeve za primopredaju vezane za zadanog korisnika.
+     *
+     * @param userId identifikator korisnika
+     * @return lista {@link LanacNadzora} zapisa gdje je korisnik pošiljalac ili primaoc
+     */
     public List<LanacNadzora> getMojiZahtjevi(Long userId) {
         return lanacRepository.findZahtjeviZaKorisnika(userId);
     }
 
+    /**
+     * Prihvata primopredaju dokaza od strane primaoca.
+     *
+     * <p>Samo primaoc ({@code preuzeoUserId}) može potvrditi primopredaju.
+     * Primopredaja mora biti u statusu {@code 'Čeka potvrdu'}.
+     *
+     * @param unosId        identifikator unosa u lancu nadzora
+     * @param potvrdioUserId identifikator korisnika koji potvrđuje prijem
+     * @throws IllegalStateException ako unos ne postoji, korisnik nije primaoc
+     *                               ili je primopredaja već obrađena
+     */
     public void prihvatiDokaz(Long unosId, Long potvrdioUserId) {
         LanacNadzora lanac = lanacRepository.findById(unosId)
                 .orElseThrow(() -> new IllegalStateException("Unos lanca nadzora ne postoji: " + unosId));
@@ -56,6 +99,18 @@ public class LanacNadzoraService {
         lanacRepository.prihvati(unosId, potvrdioUserId);
     }
 
+    /**
+     * Kreira novu primopredaju dokaza direktno iz konteksta dokaza.
+     *
+     * <p>Stanica se automatski preuzima iz samog dokaza. Novi unos dobiva
+     * status {@code 'Čeka potvrdu'}.
+     *
+     * @param dokazId      identifikator dokaza koji se predaje
+     * @param request      DTO sa ID-em primaoca i svrhom primopredaje
+     * @param predaoUserId identifikator uposlenika koji predaje dokaz
+     * @return sačuvani {@link LanacNadzora} zapis
+     * @throws IllegalStateException ako dokaz sa zadanim ID-em ne postoji
+     */
     public LanacNadzora kreirajPrimopredaju(Long dokazId, PrimopredajaRequest request, Long predaoUserId) {
         Dokaz dokaz = dokazRepository.findById(dokazId);
         if (dokaz == null) {
@@ -74,10 +129,24 @@ public class LanacNadzoraService {
         return lanacRepository.save(lanac);
     }
 
+    /**
+     * Vraća listu primopredaja koje čekaju potvrdu od strane zadanog korisnika.
+     *
+     * @param userId identifikator primaoca
+     * @return lista {@link PrimopredajaZaPotvrduDTO} sa primopredajama na čekanju
+     */
     public List<PrimopredajaZaPotvrduDTO> getCekaPotvrduZaMene(Long userId) {
         return lanacRepository.findPrimopredajeZaPotvrdu(userId);
     }
 
+    /**
+     * Vraća listu primopredaja koje je zadani korisnik poslao, a koje su još na čekanju.
+     *
+     * <p>Za svaki zapis izračunava se {@code protekloSekundi} od trenutka slanja.
+     *
+     * @param userId identifikator pošiljaoca
+     * @return lista {@link MojaPrimopredajaDTO} sa proteklim vremenom od slanja
+     */
     public List<MojaPrimopredajaDTO> getMojaSlanjaNaPotvrdi(Long userId) {
         List<MojaPrimopredajaDTO> slanja = lanacRepository.findMojaSlanjaNaPotvrdi(userId);
         long sada = System.currentTimeMillis();
@@ -92,6 +161,20 @@ public class LanacNadzoraService {
         return slanja;
     }
 
+    /**
+     * Potvrđuje ili odbija primopredaju dokaza.
+     *
+     * <p>Dozvoljeni statusi su {@code 'Potvrđeno'} i {@code 'Odbijeno'}.
+     * Samo primaoc ({@code preuzeoUserId}) može izvršiti ovu akciju.
+     * Primopredaja mora biti u statusu {@code 'Čeka potvrdu'}.
+     *
+     * @param unosId         identifikator unosa u lancu nadzora
+     * @param status         novi status: {@code 'Potvrđeno'} ili {@code 'Odbijeno'}
+     * @param napomena       opcionalna napomena uz odluku
+     * @param potvrdioUserId identifikator korisnika koji donosi odluku
+     * @throws IllegalStateException ako status nije validan, korisnik nije primaoc
+     *                               ili je primopredaja već obrađena
+     */
     public void potvrdiIliOdbij(Long unosId, String status, String napomena, Long potvrdioUserId) {
         if (!"Potvrđeno".equals(status) && !"Odbijeno".equals(status)) {
             throw new IllegalStateException("Neispravan status potvrde: " + status);
@@ -111,6 +194,18 @@ public class LanacNadzoraService {
         lanacRepository.potvrdiIliOdbij(unosId, status, napomena, potvrdioUserId);
     }
 
+    /**
+     * Poništava primopredaju dokaza od strane pošiljaoca.
+     *
+     * <p>Samo pošiljalac ({@code predaoUserId}) može poništiti primopredaju.
+     * Poništavanje je moguće samo dok je primopredaja u statusu {@code 'Čeka potvrdu'}.
+     *
+     * @param unosId  identifikator unosa u lancu nadzora
+     * @param request DTO sa razlogom poništavanja
+     * @param userId  identifikator korisnika koji poništava (mora biti pošiljalac)
+     * @throws IllegalStateException ako unos ne postoji, korisnik nije pošiljalac
+     *                               ili primopredaja nije u statusu {@code 'Čeka potvrdu'}
+     */
     public void ponistiPrimopredaju(Long unosId, PonistiRequest request, Long userId) {
         LanacNadzora lanac = lanacRepository.findById(unosId)
                 .orElseThrow(() -> new IllegalStateException("Unos lanca nadzora ne postoji: " + unosId));

--- a/suds/src/main/java/ba/unsa/etf/suds/service/OsumnjiceniFotografijaService.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/service/OsumnjiceniFotografijaService.java
@@ -8,25 +8,58 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * Servis za upravljanje fotografijama osumnjičenih.
+ *
+ * <p>Za razliku od fotografija dokaza, fotografije osumnjičenih podržavaju
+ * izmjenu i brisanje. Orkestrira {@link OsumnjiceniFotografijaRepository}.
+ *
+ * <p>Ograničenja:
+ * <ul>
+ *   <li>Maksimalno <b>3 fotografije</b> po osumnjičenom.</li>
+ *   <li>Maksimalna veličina fajla: <b>5 MB</b>.</li>
+ *   <li>Dozvoljeni tipovi: JPEG, PNG, GIF, WebP.</li>
+ * </ul>
+ */
 @Service
 public class OsumnjiceniFotografijaService {
 
     private final OsumnjiceniFotografijaRepository osumnjiceniFotografijaRepository;
 
+    /** Konstruktorska injekcija repozitorija fotografija osumnjičenih. */
     public OsumnjiceniFotografijaService(OsumnjiceniFotografijaRepository osumnjiceniFotografijaRepository) {
         this.osumnjiceniFotografijaRepository = osumnjiceniFotografijaRepository;
     }
 
     /**
-     * Dobavljanje svih fotografija za osumnjičenog
+     * Dobavlja sve fotografije za zadanog osumnjičenog.
+     *
+     * @param osumnjiceniId identifikator osumnjičenog
+     * @return lista {@link OsumnjiceniFotografijaDTO} objekata za datog osumnjičenog
      */
     public List<OsumnjiceniFotografijaDTO> getFotografijeByOsumnjiceniId(Long osumnjiceniId) {
         return osumnjiceniFotografijaRepository.findByOsumnjiceniId(osumnjiceniId);
     }
 
     /**
-     * Upload fotografije za osumnjičenog
-     * @throws RuntimeException ako je dostignut maksimum od 3 fotografije
+     * Uploaduje novu fotografiju za zadanog osumnjičenog.
+     *
+     * <p>Primjenjuje sljedeća poslovna pravila:
+     * <ul>
+     *   <li>Maksimalno 3 fotografije po osumnjičenom — baca {@link RuntimeException} ako je limit dostignut.</li>
+     *   <li>Maksimalna veličina fajla je 5 MB.</li>
+     *   <li>Dozvoljeni MIME tipovi: {@code image/jpeg}, {@code image/png}, {@code image/gif}, {@code image/webp}.</li>
+     *   <li>Ako {@code redniBroj} nije proslijeđen, automatski se dodjeljuje sljedeći slobodni redni broj.</li>
+     * </ul>
+     *
+     * @param osumnjiceniId identifikator osumnjičenog
+     * @param file          multipart fajl koji se uploaduje
+     * @param redniBroj     željeni redni broj fotografije (1–3); ako je {@code null}, automatski se određuje
+     * @param userId        identifikator uposlenika koji uploaduje fotografiju
+     * @param opis          tekstualni opis fotografije (može biti {@code null})
+     * @throws RuntimeException ako je dostignut maksimum od 3 fotografije, fajl je prevelik
+     *                          ili je tip fajla nedozvoljen
+     * @throws IOException      ako dođe do greške pri čitanju sadržaja fajla
      */
     public void uploadFotografiju(Long osumnjiceniId, MultipartFile file, Integer redniBroj,
                                   Long userId, String opis) throws IOException {
@@ -65,7 +98,16 @@ public class OsumnjiceniFotografijaService {
     }
 
     /**
-     * Ažuriranje postojeće fotografije osumnjičenog
+     * Ažurira postojeću fotografiju osumnjičenog.
+     *
+     * <p>Validira veličinu (max 5 MB) i tip fajla (JPEG, PNG, GIF, WebP).
+     *
+     * @param fotografijaId identifikator fotografije koja se ažurira
+     * @param file          novi multipart fajl
+     * @param userId        identifikator uposlenika koji vrši izmjenu
+     * @param opis          novi tekstualni opis fotografije (može biti {@code null})
+     * @throws RuntimeException ako je fajl prevelik ili je tip fajla nedozvoljen
+     * @throws IOException      ako dođe do greške pri čitanju sadržaja fajla
      */
     public void azurirajFotografiju(Long fotografijaId, MultipartFile file,
                                     Long userId, String opis) throws IOException {
@@ -88,21 +130,29 @@ public class OsumnjiceniFotografijaService {
     }
 
     /**
-     * Brisanje fotografije osumnjičenog
+     * Briše fotografiju osumnjičenog.
+     *
+     * @param fotografijaId identifikator fotografije koja se briše
      */
     public void obrisiFotografiju(Long fotografijaId) {
         osumnjiceniFotografijaRepository.delete(fotografijaId);
     }
 
     /**
-     * Provjera da li osumnjičeni ima maksimalan broj fotografija
+     * Provjerava da li je dostignut maksimalni broj fotografija (3) za zadanog osumnjičenog.
+     *
+     * @param osumnjiceniId identifikator osumnjičenog
+     * @return {@code true} ako osumnjičeni već ima 3 fotografije, inače {@code false}
      */
     public boolean isMaxFotografijaDostignut(Long osumnjiceniId) {
         return osumnjiceniFotografijaRepository.countByOsumnjiceniId(osumnjiceniId) >= 3;
     }
 
     /**
-     * Broj preostalih mjesta za fotografije
+     * Vraća broj preostalih slobodnih mjesta za fotografije osumnjičenog.
+     *
+     * @param osumnjiceniId identifikator osumnjičenog
+     * @return broj preostalih mjesta (0–3)
      */
     public int getPreostaloMjesta(Long osumnjiceniId) {
         return 3 - osumnjiceniFotografijaRepository.countByOsumnjiceniId(osumnjiceniId);

--- a/suds/src/main/java/ba/unsa/etf/suds/service/OsumnjiceniService.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/service/OsumnjiceniService.java
@@ -13,12 +13,21 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 
+/**
+ * Servis za upravljanje osumnjičenim osobama u sistemu.
+ *
+ * <p>Orkestrira {@link OsumnjiceniRepository} i {@link AdresaRepository} kako bi
+ * atomično kreirao adresu i osumnjičenog unutar iste JDBC transakcije, te ih
+ * povezao s odgovarajućim slučajem. Sve operacije koje mijenjaju više tabela
+ * izvršavaju se ručno upravljanom transakcijom (setAutoCommit/commit/rollback).
+ */
 @Service
 public class OsumnjiceniService {
     private final OsumnjiceniRepository osumnjiceniRepository;
     private final AdresaRepository adresaRepository;
     private final DatabaseManager dbManager;
 
+    /** Konstruktorska injekcija repozitorija osumnjičenih, adresa i menadžera konekcija. */
     public OsumnjiceniService(OsumnjiceniRepository osumnjiceniRepository,
                               AdresaRepository adresaRepository,
                               DatabaseManager dbManager) {
@@ -27,14 +36,38 @@ public class OsumnjiceniService {
         this.dbManager = dbManager;
     }
 
+    /**
+     * Dohvata listu svih osumnjičenih u sistemu.
+     *
+     * @return lista svih {@link Osumnjiceni} zapisa iz baze
+     */
     public List<Osumnjiceni> getAllOsumnjiceni() {
         return osumnjiceniRepository.findAll();
     }
 
+    /**
+     * Dohvata listu osumnjičenih vezanih za određeni slučaj.
+     *
+     * @param slucajId identifikator slučaja
+     * @return lista {@link OsumnjiceniDTO} objekata za dati slučaj
+     */
     public List<OsumnjiceniDTO> getOsumnjiceniBySlucajId(Long slucajId) {
     return osumnjiceniRepository.findBySlucajId(slucajId);
 }
 
+    /**
+     * Atomično kreira adresu i osumnjičenog te ih vezuje za dati slučaj.
+     *
+     * <p>Operacija se izvršava unutar ručno upravljane JDBC transakcije:
+     * najprije se upisuje adresa, zatim osumnjičeni, a potom se kreira veza
+     * u tabeli {@code SLUCAJ_OSUMNJICENI}. U slučaju greške transakcija se
+     * poništava (rollback).
+     *
+     * @param slucajId identifikator slučaja na koji se osumnjičeni vezuje
+     * @param request  podaci o osumnjičenom i njegovoj adresi
+     * @return kreirani {@link Osumnjiceni} objekat s dodijeljenim ID-om
+     * @throws RuntimeException ako dođe do greške u JDBC transakciji
+     */
     public Osumnjiceni dodajOsumnjicenog(Long slucajId, DodajOsumnjicenogRequest request) {
         Connection conn = null;
         try {

--- a/suds/src/main/java/ba/unsa/etf/suds/service/PdfGeneratorService.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/service/PdfGeneratorService.java
@@ -19,9 +19,32 @@ import java.text.SimpleDateFormat;
 import java.util.Base64;
 import java.util.Date;
 
+/**
+ * Servis za generisanje PDF izvještaja o slučajevima.
+ *
+ * <p>Koristi iText 7 biblioteku za kreiranje strukturiranih PDF dokumenata.
+ * Font {@code DejaVuSans.ttf} učitava se s {@code classpath:fonts/} kako bi
+ * se ispravno prikazali bosanski dijakritički znakovi. Servis nema zavisnosti
+ * prema repozitorijima — prima gotov {@link IzvjestajDTO} i vraća sirove
+ * bajtove PDF dokumenta.
+ */
 @Service
 public class PdfGeneratorService {
 
+    /**
+     * Generiše PDF izvještaj za dati slučaj.
+     *
+     * <p>Dokument sadrži sljedeće sekcije (ako postoje podaci):
+     * osnovni podaci o slučaju, krivična djela, tim na slučaju, osumnjičeni
+     * (s fotografijama, max 3 po osobi), svjedoci, forenzički izvještaji,
+     * dokazi (s fotografijama, max 5 po dokazu), lanac nadzora i footer
+     * s datumom generisanja i imenom korisnika.
+     *
+     * @param izvjestaj    DTO koji sadrži sve sekcije izvještaja
+     * @param generisaoIme puno ime korisnika koji generiše izvještaj (za footer)
+     * @return niz bajtova koji predstavlja generisani PDF dokument
+     * @throws RuntimeException ako dođe do greške pri generisanju PDF-a
+     */
     public byte[] generatePdf(IzvjestajDTO izvjestaj, String generisaoIme) {
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/suds/src/main/java/ba/unsa/etf/suds/service/SlucajKrivicnoDjeloService.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/service/SlucajKrivicnoDjeloService.java
@@ -8,12 +8,21 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+/**
+ * Servis za upravljanje vezama između slučajeva i krivičnih djela.
+ *
+ * <p>Orkestrira {@link SlucajKrivicnoDjeloRepository}, {@link KrivicnoDjeloRepository}
+ * i {@link SlucajRepository} kako bi omogućio dodavanje, uklanjanje i pregled
+ * krivičnih djela vezanih za određeni slučaj. Podržava i batch operaciju za
+ * dodavanje više krivičnih djela odjednom.
+ */
 @Service
 public class SlucajKrivicnoDjeloService {
     private final SlucajKrivicnoDjeloRepository vezaRepository;
     private final KrivicnoDjeloRepository djeloRepository;
     private final SlucajRepository slucajRepository;
 
+    /** Konstruktorska injekcija repozitorija veza, krivičnih djela i slučajeva. */
     public SlucajKrivicnoDjeloService(SlucajKrivicnoDjeloRepository vezaRepository,
                                        KrivicnoDjeloRepository djeloRepository,
                                        SlucajRepository slucajRepository) {
@@ -23,7 +32,11 @@ public class SlucajKrivicnoDjeloService {
     }
 
     /**
-     * Dohvata sva krivična djela za slučaj
+     * Dohvata sva krivična djela za slučaj.
+     *
+     * @param slucajId identifikator slučaja
+     * @return lista {@link SlucajKrivicnoDjelo} veza za dati slučaj
+     * @throws RuntimeException ako slučaj s datim ID-om ne postoji
      */
     public List<SlucajKrivicnoDjelo> getDjelaZaSlucaj(Long slucajId) {
         // Provjeri da li slučaj postoji
@@ -34,7 +47,16 @@ public class SlucajKrivicnoDjeloService {
     }
 
     /**
-     * Dodaje jedno krivično djelo na slučaj
+     * Dodaje jedno krivično djelo na slučaj.
+     *
+     * <p>Provjerava postojanje slučaja i krivičnog djela, te da veza između
+     * njih još ne postoji. Ako veza već postoji, baca izuzetak.
+     *
+     * @param slucajId identifikator slučaja
+     * @param djeloId  identifikator krivičnog djela
+     * @return kreirani {@link SlucajKrivicnoDjelo} zapis veze
+     * @throws RuntimeException ako slučaj ili krivično djelo ne postoje,
+     *                          ili ako veza već postoji
      */
     public SlucajKrivicnoDjelo dodajDjeloNaSlucaj(Long slucajId, Long djeloId) {
         // Provjeri da li slučaj postoji
@@ -54,7 +76,15 @@ public class SlucajKrivicnoDjeloService {
     }
 
     /**
-     * Dodaje više krivičnih djela na slučaj odjednom
+     * Dodaje više krivičnih djela na slučaj odjednom (batch operacija).
+     *
+     * <p>Provjerava postojanje slučaja i svakog krivičnog djela u listi.
+     * Lista ne smije biti prazna.
+     *
+     * @param slucajId identifikator slučaja
+     * @param djeloIds lista identifikatora krivičnih djela koja se dodaju
+     * @throws RuntimeException          ako slučaj ili bilo koje krivično djelo ne postoji
+     * @throws IllegalArgumentException  ako je lista {@code djeloIds} null ili prazna
      */
     public void dodajViseDjelaNaSlucaj(Long slucajId, List<Long> djeloIds) {
         // Provjeri da li slučaj postoji
@@ -75,14 +105,19 @@ public class SlucajKrivicnoDjeloService {
     }
 
     /**
-     * Uklanja krivično djelo sa slučaja
+     * Uklanja krivično djelo sa slučaja prema ID-u veze.
+     *
+     * @param vezaId identifikator zapisa veze u tabeli {@code SLUCAJ_KRIVICNO_DJELO}
      */
     public void ukloniDjeloSaSlucaja(Long vezaId) {
         vezaRepository.ukloniVezu(vezaId);
     }
 
     /**
-     * Uklanja sva krivična djela sa slučaja
+     * Uklanja sva krivična djela sa slučaja.
+     *
+     * @param slucajId identifikator slučaja čije se sve veze brišu
+     * @throws RuntimeException ako slučaj s datim ID-om ne postoji
      */
     public void ukloniSvaDjelaSaSlucaja(Long slucajId) {
         // Provjeri da li slučaj postoji

--- a/suds/src/main/java/ba/unsa/etf/suds/service/SlucajService.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/service/SlucajService.java
@@ -21,6 +21,16 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+/**
+ * Servis za upravljanje krivičnim slučajevima.
+ *
+ * <p>Orkestrira {@link SlucajRepository}, {@link AdresaRepository},
+ * {@link TimNaSlucajuRepository}, {@link IzvjestajRepository},
+ * {@link PdfGeneratorService} i {@link DokazRepository} kako bi podržao
+ * kompletan životni ciklus slučaja: kreiranje, pregled, ažuriranje statusa
+ * i generisanje PDF izvještaja. Kreiranje slučaja izvršava se unutar ručno
+ * upravljane JDBC transakcije.
+ */
 @Service
 public class SlucajService {
     private final SlucajRepository slucajRepository;
@@ -31,6 +41,7 @@ public class SlucajService {
     private final IzvjestajRepository izvjestajRepository;
     private final DokazRepository dokazRepository;
 
+    /** Konstruktorska injekcija repozitorija slučajeva, adresa, tima, izvještaja, PDF generatora i dokaza. */
     // Ažuriraj konstruktor da uključi nove zavisnosti
     public SlucajService(SlucajRepository slucajRepository,
                          AdresaRepository adresaRepository,
@@ -48,6 +59,20 @@ public class SlucajService {
         this.dokazRepository = dokazRepository;
     }
 
+    /**
+     * Generiše PDF izvještaj za dati slučaj i sprema ga u bazu.
+     *
+     * <p>Dohvata sve sekcije izvještaja (krivična djela, tim, osumnjičeni s fotografijama,
+     * svjedoci, dokazi s fotografijama, lanac nadzora, forenzički izvještaji) putem
+     * {@link IzvjestajRepository}, delegira generisanje PDF-a servisu {@link PdfGeneratorService},
+     * a zatim sprema generisani dokument u tabelu {@code IZVJESTAJI_SLUCAJEVA}.
+     *
+     * @param slucajId identifikator slučaja za koji se generiše izvještaj
+     * @param userId   identifikator korisnika koji generiše izvještaj (za footer i zapis)
+     * @return niz bajtova generisanog PDF dokumenta
+     * @throws IllegalArgumentException ako slučaj s datim ID-om ne postoji
+     * @throws RuntimeException         ako dođe do greške pri generisanju PDF-a
+     */
     public byte[] generatePdfReport(Long slucajId, Long userId) {
         // Dohvati sve podatke za izvještaj
         Optional<IzvjestajDTO.SlucajInfo> slucajInfo = izvjestajRepository.findSlucajInfo(slucajId);
@@ -109,10 +134,28 @@ public class SlucajService {
         return "Nepoznat korisnik";
     }
 
+    /**
+     * Dohvata detalje slučaja prema broju slučaja.
+     *
+     * @param brojSlucaja jedinstveni broj slučaja (npr. "SL-2024-001")
+     * @return {@link SlucajDetaljiDTO} s kompletnim podacima o slučaju
+     */
     public SlucajDetaljiDTO getSlucajDetalji(String brojSlucaja) {
         return slucajRepository.findDetaljiByBroj(brojSlucaja);
     }
 
+    /**
+     * Atomično kreira adresu, slučaj i tim na slučaju unutar jedne JDBC transakcije.
+     *
+     * <p>Novi slučaj dobiva inicijalni status {@code "Otvoren"}. Ako je u zahtjevu
+     * proslijeđen tim, svaki član se dodaje u tabelu {@code TIM_NA_SLUCAJU}.
+     * U slučaju greške transakcija se poništava (rollback).
+     *
+     * @param request        podaci za kreiranje slučaja (adresa, broj, opis, tim)
+     * @param voditeljUserId ID korisnika koji postaje voditelj slučaja
+     * @return {@link SlucajListDTO} s podacima o kreiranom slučaju i voditelju
+     * @throws RuntimeException ako dođe do greške u JDBC transakciji
+     */
     public SlucajListDTO kreirajSlucaj(KreirajSlucajRequest request, Long voditeljUserId) {
         Connection conn = null;
         try {
@@ -172,18 +215,56 @@ public class SlucajService {
         }
     }
 
+    /**
+     * Dohvata slučajeve na kojima je korisnik direktno angažovan (voditelj ili član tima).
+     *
+     * <p>Za razliku od {@link #getSlucajeviFiltered}, ova metoda vraća {@link MojSlucajDTO}
+     * koji uključuje ulogu korisnika na slučaju.
+     *
+     * @param userId   identifikator korisnika
+     * @param roleName naziv sistemske uloge korisnika (npr. {@code "INSPEKTOR"})
+     * @return lista {@link MojSlucajDTO} objekata za datog korisnika
+     */
     public List<MojSlucajDTO> getMojiSlucajevi(Long userId, String roleName) {
         return slucajRepository.findMojiSlucajevi(userId, roleName);
     }
 
+    /**
+     * Dohvata filtrirani spisak slučajeva prema ulozi korisnika.
+     *
+     * <p>Filtriranje se vrši na nivou repozitorija — npr. {@code SEF_STANICE} vidi
+     * sve slučajeve svoje stanice, dok {@code INSPEKTOR} vidi samo slučajeve na
+     * kojima je voditelj ili član tima.
+     *
+     * @param userId   identifikator korisnika
+     * @param roleName naziv sistemske uloge korisnika
+     * @return lista {@link SlucajListDTO} objekata prema pravilima filtriranja
+     */
     public List<SlucajListDTO> getSlucajeviFiltered(Long userId, String roleName) {
         return slucajRepository.findAllFiltered(userId, roleName);
     }
 
+    /**
+     * Dohvata slučaj prema internom ID-u.
+     *
+     * @param id interni identifikator slučaja
+     * @return {@link Optional} s {@link SlucajListDTO} ako slučaj postoji
+     */
     public Optional<SlucajListDTO> getSlucajById(Long id) {
         return slucajRepository.findByIdWithVoditelj(id);
     }
 
+    /**
+     * Ažurira status slučaja.
+     *
+     * <p>Dozvoljeni statusi su: {@code "Otvoren"}, {@code "Zatvoren"} i {@code "Arhiviran"}.
+     * Svaki drugi status uzrokuje {@link IllegalArgumentException}.
+     *
+     * @param id     identifikator slučaja
+     * @param status novi status slučaja
+     * @return {@code true} ako je ažuriranje uspješno izvršeno
+     * @throws IllegalArgumentException ako je proslijeđeni status nevalidan
+     */
     public boolean updateSlucajStatus(Long id, String status) {
         Set<String> allowedStatuses = Set.of("Otvoren", "Zatvoren", "Arhiviran");
         if (status == null || !allowedStatuses.contains(status)) {
@@ -192,6 +273,14 @@ public class SlucajService {
         return slucajRepository.updateStatus(id, status);
     }
 
+    /**
+     * Dohvata djelimični izvještaj o slučaju (bez forenzičkih izvještaja i osumnjičenih).
+     *
+     * <p>Sadrži: osnovne podatke o slučaju, dokaze, lanac nadzora, tim i svjedoke.
+     *
+     * @param slucajId identifikator slučaja
+     * @return {@link Optional} s {@link IzvjestajDTO} ako slučaj postoji
+     */
     public Optional<IzvjestajDTO> getIzvjestaj(Long slucajId) {
         Optional<IzvjestajDTO.SlucajInfo> slucajInfo = izvjestajRepository.findSlucajInfo(slucajId);
         if (slucajInfo.isEmpty()) {

--- a/suds/src/main/java/ba/unsa/etf/suds/service/StanicaService.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/service/StanicaService.java
@@ -8,25 +8,56 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+/**
+ * Servis za upravljanje policijskim stanicama.
+ *
+ * <p>Orkestrira {@link StanicaRepository} i {@link BCryptPasswordEncoder} kako bi
+ * podržao pregled i registraciju stanica. Registracija stanice je atomična operacija
+ * koja kreira adresu, stanicu, NBP korisnika i profil uposlenika s ulogom
+ * {@code SEF_STANICE} (hardkodirani ID uloge: 100).
+ */
 @Service
 public class StanicaService {
     private final StanicaRepository repository;
     private final BCryptPasswordEncoder passwordEncoder;
 
+    /** Konstruktorska injekcija repozitorija stanica i enkodera lozinki. */
     public StanicaService(StanicaRepository repository, BCryptPasswordEncoder passwordEncoder) {
         this.repository = repository;
         this.passwordEncoder = passwordEncoder;
     }
 
+    /**
+     * Dohvata listu svih policijskih stanica.
+     *
+     * @return lista svih {@link Stanica} zapisa iz baze
+     */
     public List<Stanica> getAll() {
         return repository.findAll();
     }
 
+    /**
+     * Dohvata stanicu prema ID-u.
+     *
+     * @param id identifikator stanice
+     * @return {@link Stanica} objekat
+     * @throws RuntimeException ako stanica s datim ID-om ne postoji
+     */
     public Stanica getById(Long id) {
         return repository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Stanica nije pronađena u bazi!"));
     }
 
+    /**
+     * Registruje novu policijsku stanicu zajedno s inicijalnim šefom stanice.
+     *
+     * <p>Lozinka se enkodira BCrypt algoritmom prije pohrane. Delegira atomičnu
+     * operaciju metodi {@code repository.registerStanicaITips} koja kreira:
+     * adresu, stanicu, NBP korisnika i profil uposlenika s ulogom
+     * {@code SEF_STANICE} (ID uloge: 100).
+     *
+     * @param req podaci za registraciju stanice i šefa (uključujući lozinku u čistom tekstu)
+     */
     public void registerStanica(RegistrationRequest req) {
         String hashedPw = passwordEncoder.encode(req.getPassword());
         req.setPassword(hashedPw);

--- a/suds/src/main/java/ba/unsa/etf/suds/service/SvjedokService.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/service/SvjedokService.java
@@ -13,12 +13,22 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 
+/**
+ * Servis za upravljanje svjedocima u krivičnim slučajevima.
+ *
+ * <p>Orkestrira {@link SvjedokRepository} i {@link AdresaRepository} kako bi
+ * atomično kreirao adresu i svjedoka unutar iste JDBC transakcije, te ih
+ * direktno vezao za odgovarajući slučaj putem {@code svjedok.setSlucajId}.
+ * Sve operacije koje mijenjaju više tabela izvršavaju se ručno upravljanom
+ * transakcijom (setAutoCommit/commit/rollback).
+ */
 @Service
 public class SvjedokService {
     private final SvjedokRepository svjedokRepository;
     private final AdresaRepository adresaRepository;
     private final DatabaseManager dbManager;
 
+    /** Konstruktorska injekcija repozitorija svjedoka, adresa i menadžera konekcija. */
     public SvjedokService(SvjedokRepository svjedokRepository,
                           AdresaRepository adresaRepository,
                           DatabaseManager dbManager) {
@@ -27,14 +37,37 @@ public class SvjedokService {
         this.dbManager = dbManager;
     }
 
+    /**
+     * Dohvata listu svih svjedoka u sistemu.
+     *
+     * @return lista svih {@link Svjedok} zapisa iz baze
+     */
     public List<Svjedok> getAllSvjedoci() {
         return svjedokRepository.findAll();
     }
 
+    /**
+     * Dohvata listu svjedoka vezanih za određeni slučaj.
+     *
+     * @param slucajId identifikator slučaja
+     * @return lista {@link SvjedokDTO} objekata za dati slučaj
+     */
     public List<SvjedokDTO> getSvjedociBySlucajId(Long slucajId) {
         return svjedokRepository.findBySlucajId(slucajId);
     }
 
+    /**
+     * Atomično kreira adresu i svjedoka te ih vezuje za dati slučaj.
+     *
+     * <p>Operacija se izvršava unutar ručno upravljane JDBC transakcije.
+     * Polje {@code ulicaIBroj} ima prednost nad poljem {@code adresa} u zahtjevu.
+     * U slučaju greške transakcija se poništava (rollback).
+     *
+     * @param slucajId identifikator slučaja na koji se svjedok vezuje
+     * @param request  podaci o svjedoku i njegovoj adresi
+     * @return kreirani {@link Svjedok} objekat
+     * @throws RuntimeException ako dođe do greške u JDBC transakciji
+     */
     public Svjedok dodajSvjedoka(Long slucajId, DodajSvjedokaRequest request) {
         Connection conn = null;
         try {

--- a/suds/src/main/java/ba/unsa/etf/suds/service/TimService.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/service/TimService.java
@@ -9,19 +9,45 @@ import org.springframework.stereotype.Service;
 import java.sql.Timestamp;
 import java.util.List;
 
+/**
+ * Servis za upravljanje timovima na krivičnim slučajevima.
+ *
+ * <p>Orkestrira {@link TimNaSlucajuRepository} kako bi podržao dodavanje,
+ * uklanjanje i pregled članova tima. Polje {@code ulogaNaSlucaju} je slobodan
+ * tekstualni opis uloge na konkretnom slučaju (npr. "Vođa istrage") i ne
+ * odgovara sistemskoj ulozi korisnika ({@code INSPEKTOR}, {@code POLICAJAC} itd.).
+ */
 @Service
 public class TimService {
 
     private final TimNaSlucajuRepository timNaSlucajuRepository;
 
+    /** Konstruktorska injekcija repozitorija tima na slučaju. */
     public TimService(TimNaSlucajuRepository timNaSlucajuRepository) {
         this.timNaSlucajuRepository = timNaSlucajuRepository;
     }
 
+    /**
+     * Dohvata listu članova tima za dati slučaj.
+     *
+     * @param caseId identifikator slučaja
+     * @return lista {@link TimClanDTO} objekata s podacima o svakom članu tima
+     */
     public List<TimClanDTO> getClanoviTima(Long caseId) {
         return timNaSlucajuRepository.findByCaseId(caseId);
     }
 
+    /**
+     * Dodaje novog člana u tim na slučaju.
+     *
+     * <p>Nakon pohrane, metoda ponovo dohvata tim kako bi vratila obogaćeni
+     * {@link TimClanDTO} s podacima o uposleniku (ime, uloga, značka itd.).
+     *
+     * @param caseId  identifikator slučaja
+     * @param request podaci o uposleniku i njegovoj ulozi na slučaju
+     * @return {@link TimClanDTO} s kompletnim podacima o novododanom članu
+     * @throws RuntimeException ako novokreirani zapis nije pronađen nakon pohrane
+     */
     public TimClanDTO dodajClanaTima(Long caseId, DodajClanaTRequest request) {
         TimNaSlucaju tim = new TimNaSlucaju();
         tim.setSlucajId(caseId);
@@ -37,6 +63,14 @@ public class TimService {
                 .orElseThrow(() -> new RuntimeException("Error while fetching newly added team member"));
     }
 
+    /**
+     * Uklanja člana tima prema ID-u dodjele.
+     *
+     * <p>Napomena: parametar je {@code dodjelaId} (ID zapisa u tabeli
+     * {@code TIM_NA_SLUCAJU}), a ne ID uposlenika.
+     *
+     * @param dodjelaId identifikator zapisa dodjele u timu
+     */
     public void ukloniClanaTima(Long dodjelaId) {
         timNaSlucajuRepository.deleteById(dodjelaId);
     }

--- a/suds/src/main/java/ba/unsa/etf/suds/service/UposlenikService.java
+++ b/suds/src/main/java/ba/unsa/etf/suds/service/UposlenikService.java
@@ -9,30 +9,67 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+/**
+ * Servis za upravljanje uposlenicima policijskih stanica.
+ *
+ * <p>Orkestrira {@link UposlenikRepository} i {@link BCryptPasswordEncoder} kako bi
+ * podržao kompletan životni ciklus uposlenika: dodavanje, pregled, promjenu statusa,
+ * ažuriranje podataka i upravljanje lozinkama. Sve operacije koje mijenjaju podatke
+ * uposlenika iz druge stanice bacaju {@link SecurityException}.
+ */
 @Service
 public class UposlenikService {
 
     private final UposlenikRepository uposlenikRepository;
     private final BCryptPasswordEncoder passwordEncoder;
 
+    /** Konstruktorska injekcija repozitorija uposlenika i enkodera lozinki. */
     public UposlenikService(UposlenikRepository uposlenikRepository, BCryptPasswordEncoder passwordEncoder) {
         this.uposlenikRepository = uposlenikRepository;
         this.passwordEncoder = passwordEncoder;
     }
 
+    /**
+     * Dohvata listu svih uposlenika u sistemu.
+     *
+     * @return lista {@link UposlenikDTO} objekata za sve uposlenike
+     */
     public List<UposlenikDTO> getAllUposlenici() {
         return uposlenikRepository.findAllUposlenici();
     }
 
+    /**
+     * Dohvata uposlenika prema ID-u korisnika.
+     *
+     * @param id identifikator korisnika ({@code NBP_USER.ID})
+     * @return {@link UposlenikDTO} s podacima o uposleniku
+     * @throws RuntimeException ako uposlenik s datim ID-om nije pronađen
+     */
     public UposlenikDTO getUposlenikById(Long id) {
         return uposlenikRepository.findByUserId(id)
                 .orElseThrow(() -> new RuntimeException("Uposlenik sa ID " + id + " nije pronađen!"));
     }
 
+    /**
+     * Dohvata listu uposlenika koji pripadaju određenoj stanici.
+     *
+     * @param stanicaId identifikator policijske stanice
+     * @return lista {@link UposlenikDTO} objekata za datu stanicu
+     */
     public List<UposlenikDTO> getUposleniciPoStanici(Long stanicaId) {
         return uposlenikRepository.findAllByStanicaId(stanicaId);
     }
 
+    /**
+     * Dodaje novog uposlenika u stanicu.
+     *
+     * <p>Provjerava jedinstvenost emaila, korisničkog imena i broja značke.
+     * Lozinka se enkodira BCrypt algoritmom prije pohrane.
+     *
+     * @param request   podaci o novom uposleniku (uključujući lozinku u čistom tekstu)
+     * @param stanicaId identifikator stanice kojoj uposlenik pripada
+     * @throws RuntimeException ako email, korisničko ime ili broj značke već postoje
+     */
     //Dodavanje uposlenika
     public void dodajUposlenika(DodajUposlenikaRequest request, Long stanicaId) {
         // Provjera da li već postoji
@@ -55,6 +92,22 @@ public class UposlenikService {
 
     
 
+    /**
+     * Mijenja status uposlenika (npr. aktivacija, penzionisanje, otpuštanje).
+     *
+     * <p>Sigurnosna pravila:
+     * <ul>
+     *   <li>Uposlenik mora pripadati istoj stanici kao trenutni korisnik.</li>
+     *   <li>Zadnji aktivni {@code SEF_STANICE} ne može biti otpušten ni penzionisan.</li>
+     * </ul>
+     *
+     * @param userId           identifikator uposlenika čiji se status mijenja
+     * @param request          zahtjev s novim statusom
+     * @param currentStanicaId identifikator stanice trenutno prijavljenog korisnika
+     * @param currentUserId    identifikator trenutno prijavljenog korisnika
+     * @throws SecurityException ako uposlenik pripada drugoj stanici ili bi
+     *                           otpuštanje/penzionisanje ostavilo stanicu bez šefa
+     */
     //Promjena statusa (sa sigurnosnom bravom)
     public void promijeniStatus(Long userId, PromijeniStatusRequest request, Long currentStanicaId, Long currentUserId) {
         // Provjera da li uposlenik pripada istoj stanici
@@ -80,6 +133,19 @@ public class UposlenikService {
         uposlenikRepository.updateStatus(userId, noviStatus);
     }
 
+   /**
+    * Ažurira osnovne podatke uposlenika (ime, prezime, email).
+    *
+    * <p>Uposlenik mora pripadati istoj stanici kao trenutni korisnik.
+    * Provjerava se jedinstvenost emaila — novi email ne smije biti zauzet
+    * od strane drugog korisnika.
+    *
+    * @param targetUserId     identifikator uposlenika čiji se podaci ažuriraju
+    * @param request          DTO s novim podacima (ime, prezime, email)
+    * @param currentStanicaId identifikator stanice trenutno prijavljenog korisnika
+    * @throws SecurityException ako uposlenik pripada drugoj stanici
+    * @throws RuntimeException  ako je novi email već zauzet
+    */
    public void azurirajPodatke(Long targetUserId, UposlenikDTO request, Long currentStanicaId) {
     if (!uposlenikRepository.isUserInStanica(targetUserId, currentStanicaId)) {
         throw new SecurityException("Nemate pravo mijenjati podatke uposlenika iz druge stanice!");
@@ -95,6 +161,18 @@ public class UposlenikService {
         request.getEmail()
     );
 }
+    /**
+     * Resetuje lozinku uposlenika (administrativna akcija šefa stanice).
+     *
+     * <p>Uposlenik mora pripadati istoj stanici kao trenutni korisnik.
+     * Nova lozinka se enkodira BCrypt algoritmom. Pristup ovoj metodi
+     * ograničen je na {@code SEF_STANICE} ulogom na nivou kontrolera.
+     *
+     * @param targetUserId     identifikator uposlenika čija se lozinka resetuje
+     * @param novaLozinka      nova lozinka u čistom tekstu
+     * @param currentStanicaId identifikator stanice trenutno prijavljenog korisnika
+     * @throws SecurityException ako uposlenik pripada drugoj stanici
+     */
     public void resetujLozinku(Long targetUserId, String novaLozinka, Long currentStanicaId) {
         if (!uposlenikRepository.isUserInStanica(targetUserId, currentStanicaId)) {
             throw new SecurityException("Nemate pravo mijenjati lozinku uposlenika iz druge stanice!");
@@ -103,6 +181,18 @@ public class UposlenikService {
         uposlenikRepository.updatePassword(targetUserId, encoded);
     }
 
+    /**
+     * Omogućava korisniku da sam promijeni svoju lozinku.
+     *
+     * <p>Stara lozinka mora odgovarati trenutno pohranjenoj hash vrijednosti.
+     * Nova lozinka se enkodira BCrypt algoritmom. Svaki prijavljeni korisnik
+     * može koristiti ovu metodu za vlastiti nalog.
+     *
+     * @param userId identifikator korisnika koji mijenja lozinku
+     * @param stara  stara lozinka u čistom tekstu (za verifikaciju)
+     * @param nova   nova lozinka u čistom tekstu
+     * @throws RuntimeException ako stara lozinka nije ispravna
+     */
     public void promijeniLicnuLozinku(Long userId, String stara, String nova) {
         String trenutnaLozinkaHash = uposlenikRepository.getPasswordByUserId(userId);
         


### PR DESCRIPTION
## Summary

Implements **issue #27** — a complete documentation set for SUDS (*Šta aplikacija
radi, Tech Stack, yml/env, Arhitektura, API, DB schema, Setup, User guideline*) plus
**Bosnian Javadoc on every backend Java class**.

Two coherent commits:

1. **`5697052` · `docs(readme): rewrite with wiki links and accurate stack info`** —
   replaces the README with a concise overview linking to every wiki page and
   describing both backend + frontend.
2. **`447d1d8` · `docs(javadoc): annotate every backend class with Bosnian Javadoc`** —
   adds 810 `/** ... */` blocks across all 107 backend Java files, plus
   `maven-javadoc-plugin 3.11.2` so `mvn javadoc:javadoc` generates a navigable
   HTML site under `suds/target/reports/apidocs/`.

The bulk of the prose documentation lives in the **[GitHub Wiki](https://github.com/Zukic98/NBP-project/wiki)** (separate `.wiki` repository, already pushed).

## Wiki content (already on `origin/master` of the `.wiki` repo)

| Page | Content |
| --- | --- |
| [Home](https://github.com/Zukic98/NBP-project/wiki/Home) | Landing page with full navigation index |
| [01 About the Project](https://github.com/Zukic98/NBP-project/wiki/01-About-The-Project) | What SUDS does, problem solved, key features |
| [02 Tech Stack](https://github.com/Zukic98/NBP-project/wiki/02-Tech-Stack) | Every dependency (backend + frontend) with versions |
| [03 Architecture](https://github.com/Zukic98/NBP-project/wiki/03-Architecture) | 4 Mermaid diagrams: system, 3-tier, request lifecycle, auth |
| [04 Setup Guide](https://github.com/Zukic98/NBP-project/wiki/04-Setup-Guide) | Prereqs, step-by-step install, troubleshooting, **`mvn javadoc:javadoc`** instructions |
| [05 Configuration](https://github.com/Zukic98/NBP-project/wiki/05-Configuration) | Every `application.yml` & `.env` key explained |
| [06 Database Schema](https://github.com/Zukic98/NBP-project/wiki/06-Database-Schema) | Full Mermaid ER diagram + per-table reference |
| [07 API Reference](https://github.com/Zukic98/NBP-project/wiki/07-API-Reference) | All 48 endpoints grouped by tag, with examples |
| [08 Auth & Authz](https://github.com/Zukic98/NBP-project/wiki/08-Authentication-Authorization) | JWT claims, login + per-request flow (sequence diagrams) |
| [09 Chain of Custody](https://github.com/Zukic98/NBP-project/wiki/09-Chain-of-Custody) | State machine + worked-example sequence diagram |
| [10 Frontend Architecture](https://github.com/Zukic98/NBP-project/wiki/10-Frontend-Architecture) | Component tree, role-driven rendering |
| [11–14 User Guides](https://github.com/Zukic98/NBP-project/wiki) | One per role: *Šef stanice*, *Inspektor*, *Policajac*, *Forenzičar* |
| `_Sidebar.md` / `_Footer.md` | GitHub Wiki navigation chrome |

**Total: 17 wiki pages, 3 100+ lines of documentation, 12 Mermaid diagrams.**

## Codebase Javadoc (NEW in this PR)

Every backend Java file now carries Bosnian Javadoc on its class, public methods,
constructors and POJO fields. Style follows the project's existing convention from
`suds/AGENTS.md` (\"Bosnian/Croatian naming for domain classes, methods, test names,
Javadoc\").

| Package | Files | Javadoc blocks |
| --- | ---: | ---: |
| `model/` (POJOs mapping DB tables) | 18 | 135 |
| `dto/` (request + response shapes) | 33 | 293 |
| `repository/` (JDBC data layer) | 17 | 158 |
| `service/` (business logic) | 16 | 103 |
| `controller/` (REST handlers) | 17 | 98 |
| `config/` (DB, Security, OpenAPI) | 3 | 10 |
| `security/` (JwtUtil, JwtFilter) | 2 | 13 |
| Root (`SudsApplication`) | 1 | 2 |
| **Total** | **107** | **810** |

What the Javadoc captures:

- **Class-level**: which Oracle table the class maps to, role in the system, FK relationships.
- **Field-level on POJOs**: one line per field correlating the Java field to its `UPPERCASE_BOSNIAN` column.
- **Method-level**: proper `@param` / `@return` / `@throws` tags.
- **Business rules**: RBAC (`@PreAuthorize` rules in prose), chain-of-custody state
  machine, same-station enforcement, BLOB photo limits (10 MB / 5 MB), photo
  INSERT-only chain-of-custody rule, last-`SEF_STANICE`-deactivation guard, etc.
- **Private helpers** (`mapRowToXxx`, etc.) intentionally left undocumented per the
  project convention.

**Zero functional changes**: no signature, annotation, import, SQL, or logic touched.

### Generating the Javadoc HTML

`maven-javadoc-plugin 3.11.2` is added to `suds/pom.xml`. Run:

```bash
cd suds
mvn javadoc:javadoc
# → suds/target/reports/apidocs/index.html  (268 HTML files, fully navigable)
```

The generated site has package overviews, class details, searchable index, and the
window title \"SUDS — Sistem za upravljanje dokazima i slučajevima\".

## Verification performed

| Check | Result |
| --- | --- |
| All 12 Mermaid diagrams parse cleanly via the official `mermaid` parser | ✅ |
| Wiki renders on GitHub — every page reachable, Mermaid blocks recognised | ✅ |
| `mvn -DskipTests compile` | ✅ exit 0 (only pre-existing Lombok warnings) |
| `mvn javadoc:javadoc` | ✅ exit 0, 268 HTML files, no errors/warnings |
| Generated apidocs window title is correct + contains Bosnian content | ✅ verified `Slucaj.html` contains *\"POJO koji reprezentira jedan red u tabeli SLUCAJEVI…\"* |
| All 7 packages present in apidocs | ✅ `config`, `controller`, `dto`, `model`, `repository`, `security`, `service` |
| `mvn spring-boot:run` boots cleanly | ✅ start in 2.4 s |
| `GET /v3/api-docs` | ✅ HTTP 200, 48 paths, `bearerAuth` JWT scheme |
| `GET /swagger-ui.html` | ✅ HTTP 302 → `/swagger-ui/index.html` (Swagger UI bundle loads) |
| `GET /api/slucajevi` (no token) | ✅ HTTP 403 (security still enforced) |
| `GET /api/adrese` (public) | ✅ HTTP 200 |

## Files changed in this PR

```
README.md                                        rewritten
suds/pom.xml                                     + maven-javadoc-plugin 3.11.2
suds/src/main/java/ba/unsa/etf/suds/**/*.java    107 files annotated (Javadoc-only)
```

109 files changed, 3 842 insertions(+), 91 deletions(-) compared with `main`.

Closes #27.